### PR TITLE
Add react-tooltip overlay on auction noun to display traits

### DIFF
--- a/packages/nouns-webapp/package.json
+++ b/packages/nouns-webapp/package.json
@@ -45,6 +45,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "react-stepz": "^1.0.2",
+    "react-tooltip": "^4.2.21",
     "redux": "^4.1.0",
     "remark-breaks": "^3.0.1",
     "wagmi": "^0.4.1",

--- a/packages/nouns-webapp/src/components/Noun/index.tsx
+++ b/packages/nouns-webapp/src/components/Noun/index.tsx
@@ -2,6 +2,7 @@ import classes from './Noun.module.css';
 import React from 'react';
 import loadingNoun from '../../assets/lil-loading-skull.gif';
 import Image from 'react-bootstrap/Image';
+import NounTraitsOverlay from '../NounTraitsOverlay';
 
 export const LoadingNoun = () => {
   return (
@@ -16,16 +17,19 @@ const Noun: React.FC<{
   alt: string;
   className?: string;
   wrapperClassName?: string;
+  parts?: { filename: string }[];
 }> = props => {
-  const { imgPath, alt, className, wrapperClassName } = props;
+  const { imgPath, alt, className, wrapperClassName, parts } = props;
+
   return (
-    <div className={`${classes.imgWrapper} ${wrapperClassName}`}>
+    <div className={`${classes.imgWrapper} ${wrapperClassName}`} data-tip data-for="noun-traits">
       <Image
         className={`${classes.img} ${className}`}
         src={imgPath ? imgPath : loadingNoun}
         alt={alt}
         fluid
       />
+      {Boolean(parts?.length) && <NounTraitsOverlay parts={parts!} />}
     </div>
   );
 };

--- a/packages/nouns-webapp/src/components/NounTraitsOverlay/NounTraitsOverlay.module.css
+++ b/packages/nouns-webapp/src/components/NounTraitsOverlay/NounTraitsOverlay.module.css
@@ -1,0 +1,12 @@
+.traitList {
+  list-style: none;
+  margin: 0;
+  padding: 8px;
+}
+
+.traitList li {
+  padding: 4px 0;
+  text-transform: capitalize;
+  font-family: 'Londrina Solid';
+  font-size: 23px;
+}

--- a/packages/nouns-webapp/src/components/NounTraitsOverlay/index.tsx
+++ b/packages/nouns-webapp/src/components/NounTraitsOverlay/index.tsx
@@ -1,0 +1,36 @@
+import classes from './NounTraitsOverlay.module.css';
+import React from 'react';
+import ReactTooltip from 'react-tooltip';
+
+const NounTraitsOverlay: React.FC<{
+  parts: { filename: string }[];
+}> = props => {
+  const { parts } = props;
+  const getNounTrait = (part: { filename: string }) => {
+    const splitData: string[] = part.filename.split('-');
+    return {trait: splitData[0], value: splitData.slice(1).join(' ')}
+  }
+
+  return (
+    <ReactTooltip
+      id="noun-traits"
+      place="top"
+      effect="float"
+      backgroundColor="white"
+      textColor="black"
+    >
+      <ul className={classes.traitList}>
+        {parts.map((part) => {
+          const { trait, value } = getNounTrait(part);
+          return (
+            <li key={trait}>
+              {trait}: {value}
+            </li>
+          )
+        })}
+      </ul>
+    </ReactTooltip>
+  );
+};
+
+export default NounTraitsOverlay;

--- a/packages/nouns-webapp/src/components/StandaloneNoun/index.tsx
+++ b/packages/nouns-webapp/src/components/StandaloneNoun/index.tsx
@@ -33,6 +33,7 @@ const getNoun = (nounId: string | EthersBN, seed: INounSeed) => {
     name,
     description,
     image,
+    parts,
   };
 };
 
@@ -129,9 +130,9 @@ export const StandaloneNounWithSeed: React.FC<StandaloneNounWithSeedProps> = (
     dispatch(setOnDisplayAuctionNounId(nounId.toNumber()));
   };
 
-  const { image, description } = getNoun(nounId, seed);
+  const { image, description, parts } = getNoun(nounId, seed);
 
-  const noun = <Noun imgPath={image} alt={description} />;
+  const noun = <Noun imgPath={image} alt={description} parts={parts} />;
   const nounWithLink = (
     <Link
       to={'/lilnoun/' + nounId.toString()}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19382,6 +19382,14 @@ react-stepz@^1.0.2:
   dependencies:
     tiny-invariant "^1.1.0"
 
+react-tooltip@^4.2.21:
+  version "4.2.21"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.21.tgz#840123ed86cf33d50ddde8ec8813b2960bfded7f"
+  integrity sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react-transition-group@^4.4.1:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
@@ -22815,6 +22823,11 @@ uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
Adding an overlay to the auction showing the traits of the current Noun. The overlay appears when hovering over the Noun.

I've added react-tooltip as a dependency for this.

https://user-images.githubusercontent.com/7782211/171491377-434e0bac-ef84-4c3a-8aed-28f3246e5b6c.mov

