### PR TITLE
fix: update mint time logic for reserved Lil Nouns

### DIFF
--- a/packages/nouns-webapp/src/utils/nounderNoun.ts
+++ b/packages/nouns-webapp/src/utils/nounderNoun.ts
@@ -42,8 +42,14 @@ export const generateEmptyNounderAuction = (
   pastAuctions: AuctionState[],
 ): Auction => {
   const nounderAuction = emptyNounderAuction(nounId.toNumber());
-  // use nounderAuction.nounId + 1 to get mint time
-  const auctionAbove = findAuction(nounId.add(1), pastAuctions);
+
+  // When the 9th Lil Noun's auction is settled, three events occur:
+  // (1) a newly minted Lil Noun is sent to the Lil Nouns DAO
+  // (2) a newly minted Lil Noun is sent to the Nouns DAO
+  // (3) a new Lil Noun auction is started (`auctionAbove`)
+  // Since neither (1) nor (2) go through an auction, their `startTime` is derived from the `auctionAbove`.
+  const distanceToAuctionAbove = isNounderNoun(BigNumber.from(nounId)) ? 2 : 1;
+  const auctionAbove = findAuction(nounId.add(distanceToAuctionAbove), pastAuctions);
   const auctionAboveStartTime = auctionAbove && BigNumber.from(auctionAbove.startTime);
   if (auctionAboveStartTime) nounderAuction.startTime = auctionAboveStartTime.toJSON();
 


### PR DESCRIPTION
## Summary

Closes https://github.com/lilnounsDAO/lilnouns-monorepo/issues/28

Currently, all Lil Nouns sent to the Lil Nouns DAO show a mint date of January 01, 1970.   This PR updates the logic so the correct mint date is shown for each of these Lil Nouns.

### Why this happens

Nounder Auctions rely on a [special function](https://github.com/lilnounsDAO/lilnouns-monorepo/blob/45ba44c98025f41c4611c0c89a173e67cd4a3cf4/packages/nouns-webapp/src/utils/nounderNoun.ts#L40) initialized with a [zero-value](https://github.com/lilnounsDAO/lilnouns-monorepo/blob/45ba44c98025f41c4611c0c89a173e67cd4a3cf4/packages/nouns-webapp/src/utils/nounderNoun.ts#L18) `startTime`. Unless this function is able to [find the auction following the mint](https://github.com/lilnounsDAO/lilnouns-monorepo/blob/45ba44c98025f41c4611c0c89a173e67cd4a3cf4/packages/nouns-webapp/src/utils/nounderNoun.ts#L46-L48), its `startTime` remains at `zero` which, when [filtered through `dayjs`](https://github.com/lilnounsDAO/lilnouns-monorepo/blob/48fb228e07742e075464927ccef424f236ef1a7c/packages/nouns-webapp/src/components/AuctionActivityDateHeadline/index.tsx#L12-L14), is January 1, 1970.

The current logic assumes that the auction following the mint is exactly one "above" the current noun:

https://github.com/lilnounsDAO/lilnouns-monorepo/blob/45ba44c98025f41c4611c0c89a173e67cd4a3cf4/packages/nouns-webapp/src/utils/nounderNoun.ts#L45-L46

However, when applied to the Lil Nounders' Lil Noun, it will use the `startTime` of Nouns DAO Noun (initialized with the zero-value) rather than the auction following those mints. 

### Approach

Because there are not one but [two Lil Nouns that are minted once the 9th Lil Noun is settled](https://github.com/lilnounsDAO/lilnouns-monorepo/blob/409d5015589549120732d3fb242d1b8a6a27eb2e/packages/nouns-webapp/src/components/Documentation/index.tsx#L117-L118), this PR updates the logic to calculate the correct "distance" between the respective Lil Noun and the auction following their mints:

```ts
  const distanceToAuctionAbove = isNounderNoun(BigNumber.from(nounId)) ? 2 : 1;
  const auctionAbove = findAuction(nounId.add(distanceToAuctionAbove), pastAuctions);
```

I chose not to read directly from the blockchain to avoid any additional RPC calls, favoring logic that builds on the existing design.