### PR TITLE
github actions to deploy nouns-api

### DIFF
--- a/.github/workflows/production-api.yaml
+++ b/.github/workflows/production-api.yaml
@@ -7,6 +7,9 @@ env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
   ROLLBAR_API_KEY: ${{ secrets.ROLLBAR_API_KEY }}
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+defaults:
+  run:
+    working-directory: packages/nouns-api
 jobs:
   deploy:
     name: Deploy app
@@ -14,4 +17,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only -c packages/nouns-api/fly.toml
+      - run: flyctl deploy --remote-only --config ./fly.toml

--- a/.github/workflows/production-api.yaml
+++ b/.github/workflows/production-api.yaml
@@ -1,0 +1,17 @@
+name: Fly Deploy Production
+on:
+  push:
+    branches:
+      - production
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  ROLLBAR_API_KEY: ${{ secrets.ROLLBAR_API_KEY }}
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only -c packages/nouns-api/fly.toml

--- a/.github/workflows/production-api.yaml
+++ b/.github/workflows/production-api.yaml
@@ -17,4 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only --config ./fly.toml
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            api:
+              - 'packages/nouns-api/**'
+      # run only if 'api' files were changed
+      - name: api deploy
+        if: steps.filter.outputs.api == 'true'
+        run: flyctl deploy --remote-only --config ./fly.toml

--- a/.github/workflows/staging-api.yaml
+++ b/.github/workflows/staging-api.yaml
@@ -1,0 +1,16 @@
+name: Fly Deploy Staging
+on:
+  push:
+    branches:
+      - staging
+      - master
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only -c packages/nouns-api/fly.staging.toml

--- a/.github/workflows/staging-api.yaml
+++ b/.github/workflows/staging-api.yaml
@@ -6,6 +6,9 @@ on:
       - master
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+defaults:
+  run:
+    working-directory: packages/nouns-api
 jobs:
   deploy:
     name: Deploy app
@@ -13,4 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only -c packages/nouns-api/fly.staging.toml
+      - run: flyctl deploy --remote-only --config ./fly.staging.toml

--- a/.github/workflows/staging-api.yaml
+++ b/.github/workflows/staging-api.yaml
@@ -16,4 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only --config ./fly.staging.toml
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            api:
+              - 'packages/nouns-api/**'
+      # run only if 'api' files were changed
+      - name: api deploy
+        if: steps.filter.outputs.api == 'true'
+        run: flyctl deploy --remote-only --config ./fly.staging.toml

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,10 +4,12 @@
 
 [context."staging".environment]
   REACT_APP_CHAIN_ID = "1"
+  REACT_APP_MAINNET_NOUNSAPI = "https://lil-noun-api-staging.fly.dev"
   REACT_APP_ENABLE_HISTORY = "true"
 
 [context.deploy-preview.environment]
   REACT_APP_CHAIN_ID = "1"
+  REACT_APP_MAINNET_NOUNSAPI = "https://lil-noun-api-staging.fly.dev"
   REACT_APP_ENABLE_HISTORY = "true"
   
 [context."master".environment]

--- a/packages/nouns-api/README.md
+++ b/packages/nouns-api/README.md
@@ -1,6 +1,6 @@
 # @nouns/api
 
-A HTTP webserver that hosts token metadata. This is currently unused because on-chain, data URIs are enabled.
+A express webserver that supports the Prop Lot feature. This app uses Prisma to manage a postgres DB. In local development you will want to copy the values in `.env.example.local` to your `.env` file and update the `DATABASE_URL` to point to your local postgres instance.
 
 ## Install dependencies
 

--- a/packages/nouns-api/fly.staging.toml
+++ b/packages/nouns-api/fly.staging.toml
@@ -1,0 +1,42 @@
+# fly.toml file generated for lil-noun-api-staging on 2022-08-02T21:15:36+01:00
+
+app = "lil-noun-api-staging"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[build]
+  builder = "heroku/buildpacks:20"
+
+[env]
+  PORT = "8080"
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 8080
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"


### PR DESCRIPTION
The api currently requires someone to manually deploy via the CLI. This PR adds github actions to deploy the api to fly.io on a staging env or production env.

- The staging action deploys on merge to master and staging branch. (I think both of these are staging/pre production? @lilnounsDAO )

- The production action deploys on merge to the production branch.

The deploy step is only performed in these actions if there were changes to the nouns-api package to limit unnecessary deploys.

### AFTER DEPLOY

### Staging Updates:
- Update the `REACT_APP_MAINNET_NOUNSAPI` and `REACT_APP_RINKEBY_NOUNSAPI` env vars on the webapp staging deploys to the new staging api in fly.
- Set the `FLY_API_TOKEN` env var for the staging github action. Ask me for a auth token.

### Production Updates
- Update the `REACT_APP_RINKEBY_NOUNSAPI` env var on the webapp production deploy to also point to the new staging api. Don't want people to be able to manipulate prod data while on the rinkeby network.
- Set the `FLY_API_TOKEN` env var for the production github action. Ask me for a auth token.