### PR TITLE
Use account votes instead of balance check. Update config.

### DIFF
--- a/packages/nouns-api/.env.example.local
+++ b/packages/nouns-api/.env.example.local
@@ -1,0 +1,5 @@
+JSON_RPC_URL="http://localhost:8545"
+DATABASE_URL="postgresql://<USER>:<PASSWORD>@localhost:5432/<USER>?schema=lil-nouns-ideas"
+ACCESS_TOKEN_SECRET="lil-nouns-test"
+ROLLBAR_API_KEY="ab83b46c2bfd4763b2833e68c0e3e123"
+NOUNS_TOKEN_ADDRESS="0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"

--- a/packages/nouns-api/src/clients.ts
+++ b/packages/nouns-api/src/clients.ts
@@ -16,5 +16,5 @@ export const defaultProvider = getDefaultProvider(1, {
 export const nounsTokenContract = new Contract(
   config.nounsTokenAddress,
   NounsTokenABI,
-  defaultProvider,
+  Boolean(config.jsonRpcUrl) ? jsonRpcProvider : defaultProvider,
 );

--- a/packages/nouns-api/src/config.ts
+++ b/packages/nouns-api/src/config.ts
@@ -3,7 +3,7 @@ export const config = {
   serverPort: Number(process.env.PORT ?? 5001),
   nounsTokenAddress:
     process.env.NOUNS_TOKEN_ADDRESS ?? '0x4b10701Bfd7BFEdc47d50562b76b436fbB5BdB3B',
-  jsonRpcUrl: process.env.JSON_RPC_URL ?? 'http://localhost:8545',
+  jsonRpcUrl: process.env.JSON_RPC_URL || '',
   lilNounsJWTSecret: process.env.ACCESS_TOKEN_SECRET || 'lil-nouns-test',
   rollbarApiKey: process.env.ROLLBAR_API_KEY || '',
   nftStorageApiKey:

--- a/packages/nouns-api/src/utils/utils.ts
+++ b/packages/nouns-api/src/utils/utils.ts
@@ -2,7 +2,7 @@ import { nounsTokenContract } from '../clients';
 import { tryF, isError } from 'ts-try';
 
 export const nounTokenCount = async (account: string) => {
-  const data = await tryF(() => nounsTokenContract.balanceOf(account));
+  const data = await tryF(() => nounsTokenContract.getCurrentVotes(account));
   if (isError(data)) {
     console.error(`Error fetching votes for account ${account}: ${data.message}`);
     return;

--- a/packages/nouns-webapp/src/components/Ideas/index.tsx
+++ b/packages/nouns-webapp/src/components/Ideas/index.tsx
@@ -2,7 +2,7 @@ import { Alert, Button, Form } from 'react-bootstrap';
 import { useEthers } from '@usedapp/core';
 import { useHistory } from 'react-router-dom';
 import clsx from 'clsx';
-import { useNounTokenBalance } from '../../wrappers/nounToken';
+import { useAccountVotes } from '../../wrappers/nounToken';
 import classes from './Ideas.module.css';
 import IdeaCard from '../IdeaCard';
 import { Idea, useIdeas, SORT_BY } from '../../hooks/useIdeas';
@@ -18,7 +18,7 @@ const Ideas = () => {
     setSortBy(e.target.value);
   };
 
-  const nounBalance = useNounTokenBalance(account || undefined) ?? 0;
+  const nounBalance = useAccountVotes(account || undefined) ?? 0;
 
   const nullStateCopy = () => {
     if (Boolean(account)) {

--- a/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
@@ -14,7 +14,7 @@ import {
   Comment as CommentType,
   VoteFormData,
 } from '../../../hooks/useIdeas';
-import { useNounTokenBalance } from '../../../wrappers/nounToken';
+import { useAccountVotes } from '../../../wrappers/nounToken';
 import IdeaVoteControls from '../../../components/IdeaVoteControls';
 import moment from 'moment';
 import Davatar from '@davatar/react';
@@ -194,7 +194,7 @@ const IdeaPage = () => {
   const idea = getIdea(id);
 
   const [comment, setComment] = useState<string>('');
-  const nounBalance = useNounTokenBalance(account || undefined) ?? 0;
+  const nounBalance = useAccountVotes(account || undefined) ?? 0;
   const ens = useReverseENSLookUp(idea?.creatorId);
   const shortAddress = useShortAddress(idea?.creatorId);
 


### PR DESCRIPTION
- Use account votes instead of balance check when storing lilnoun counts against the user model. Issue raised in Discord.

- Use jsonRPC provider if provided otherwise use defaultProvider fallback.
  - We should probably be using the jsonrpc endpoint used on the webapp assuming it's paid for? This change allows us to set this via a env var if we need to. Falls back to the default infura setup by @mcgingras until then. **Not sure if the provider needs to whitelist the nouns api address to enable requests**