### PR TITLE
feat: markdown syntax modal

### DIFF
--- a/packages/nouns-webapp/src/pages/Ideas/Create/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/Create/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Col, Row } from 'react-bootstrap';
+import Modal from 'react-bootstrap/Modal';
 import { useHistory } from 'react-router-dom';
 import Section from '../../../layout/Section';
 import { useIdeas } from '../../../hooks/useIdeas';
@@ -22,6 +23,10 @@ const CreateIdeaPage = () => {
   const [tldr, setTldr] = useState<string>('');
   const [description, setDescription] = useState<string>('');
 
+  const [showMarkdownModal, setShowMarkdownModal] = useState<boolean>(false);
+  const handleCloseMarkdownModal = () => setShowMarkdownModal(false);
+  const handleShowMarkdownModal = () => setShowMarkdownModal(true);
+
   const titleValid =
     title.length <= FORM_VALIDATION.TITLE_MAX && title.length >= FORM_VALIDATION.TITLE_MIN;
   const tldrValid =
@@ -33,6 +38,61 @@ const CreateIdeaPage = () => {
 
   return (
     <Section fullWidth={false} className={classes.section}>
+      <Modal show={showMarkdownModal} onHide={handleCloseMarkdownModal} size="xl">
+        <Modal.Header closeButton>
+          <Modal.Title>Markdown Syntax</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="grid grid-cols-3 gap-8">
+            <div className="flex flex-col col-span-1">
+              <div className="flex flex-row justify-between">
+                <span># Header</span>
+                <span>heading 1</span>
+              </div>
+              <div className="flex flex-row justify-between">
+                <span>## Header</span>
+                <span>heading 2</span>
+              </div>
+              <div className="flex flex-row justify-between">
+                <span>### Header</span>
+                <span>heading 3</span>
+              </div>
+            </div>
+            <div className="flex flex-col col-span-1">
+              <div className="flex flex-row justify-between">
+                <span className="font-bold">*</span>
+                <span>bullet point</span>
+              </div>
+              <div className="flex flex-row justify-between">
+                <span>-</span>
+                <span>bullet point</span>
+              </div>
+              <div className="flex flex-row justify-between">
+                <span>1.</span>
+                <span>list items</span>
+              </div>
+              <div className="flex flex-row justify-between">
+                <span>Image</span>
+                <span>![alt-text](image.jpg)</span>
+              </div>
+              <div className="flex flex-row justify-between">
+                <span>Link</span>
+                <span>[title](https://www.example.com)</span>
+              </div>
+            </div>
+            <div className="flex flex-col col-span-1">
+              <div className="flex flex-row justify-between">
+                <span className="font-bold">**bold**</span>
+                <span>bold text</span>
+              </div>
+              <div className="flex flex-row justify-between">
+                <span className="italic">_italic_</span>
+                <span>italic text</span>
+              </div>
+            </div>
+          </div>
+        </Modal.Body>
+      </Modal>
       <Col lg={10} className={classes.wrapper}>
         <Row className={classes.headerRow}>
           <div>
@@ -100,7 +160,15 @@ const CreateIdeaPage = () => {
           </div>
           <div className="flex flex-col">
             <div className="flex justify-between w-full items-center">
-              <label className="lodrina font-bold text-2xl mb-2">Description</label>
+              <div className="space-x-2">
+                <label className="lodrina font-bold text-2xl mb-2">Description</label>
+                <span
+                  className="text-sm text-gray-500 cursor-pointer"
+                  onClick={handleShowMarkdownModal}
+                >
+                  Markdown supported
+                </span>
+              </div>
               <span className={`${!descriptionValid ? 'text-[#E40535]' : 'text-[#8C8D92]'}`}>
                 {description.length}/{FORM_VALIDATION.DESCRIPTION_MAX}
               </span>

--- a/packages/nouns-webapp/src/pages/Ideas/Create/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/Create/index.tsx
@@ -1,10 +1,13 @@
 import { useState } from 'react';
 import { Col, Row } from 'react-bootstrap';
 import Modal from 'react-bootstrap/Modal';
+import Nav from 'react-bootstrap/Nav';
 import { useHistory } from 'react-router-dom';
 import Section from '../../../layout/Section';
 import { useIdeas } from '../../../hooks/useIdeas';
 import classes from '../Ideas.module.css';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 
 enum FORM_VALIDATION {
   TITLE_MAX = 50,
@@ -27,6 +30,8 @@ const CreateIdeaPage = () => {
   const handleCloseMarkdownModal = () => setShowMarkdownModal(false);
   const handleShowMarkdownModal = () => setShowMarkdownModal(true);
 
+  const [descriptionTab, setDescriptionTab] = useState<'WRITE' | 'PREVIEW'>('WRITE');
+
   const titleValid =
     title.length <= FORM_VALIDATION.TITLE_MAX && title.length >= FORM_VALIDATION.TITLE_MIN;
   const tldrValid =
@@ -35,6 +40,10 @@ const CreateIdeaPage = () => {
     description.length <= FORM_VALIDATION.DESCRIPTION_MAX &&
     description.length >= FORM_VALIDATION.DESCRIPTION_MIN;
   const formValid = titleValid && tldrValid && descriptionValid;
+
+  const handleSelect = (e: any) => {
+    setDescriptionTab(e);
+  };
 
   return (
     <Section fullWidth={false} className={classes.section}>
@@ -173,15 +182,34 @@ const CreateIdeaPage = () => {
                 {description.length}/{FORM_VALIDATION.DESCRIPTION_MAX}
               </span>
             </div>
-            <textarea
-              maxLength={FORM_VALIDATION.DESCRIPTION_MAX}
-              minLength={FORM_VALIDATION.DESCRIPTION_MIN}
-              value={description}
-              onChange={e => setDescription(e.target.value)}
-              name="description"
-              className="border rounded-lg p-2 min-h-[240px]"
-              placeholder="Describe your idea in full..."
-            />
+            <Nav variant="tabs" defaultActiveKey="WRITE" className="mb-2" onSelect={handleSelect}>
+              <Nav.Item>
+                <Nav.Link eventKey="WRITE">Write</Nav.Link>
+              </Nav.Item>
+              <Nav.Item>
+                <Nav.Link eventKey="PREVIEW">Preview</Nav.Link>
+              </Nav.Item>
+            </Nav>
+            {descriptionTab === 'WRITE' ? (
+              <textarea
+                maxLength={FORM_VALIDATION.DESCRIPTION_MAX}
+                minLength={FORM_VALIDATION.DESCRIPTION_MIN}
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                name="description"
+                className="border rounded-lg p-2 min-h-[240px]"
+                placeholder="Describe your idea in full..."
+              />
+            ) : (
+              <div
+                className="border rounded-lg p-2 min-h-[240px]"
+                dangerouslySetInnerHTML={{
+                  __html: DOMPurify.sanitize(marked.parse(description), {
+                    ADD_ATTR: ['target'],
+                  }),
+                }}
+              />
+            )}
           </div>
           <div className="flex justify-end">
             <button


### PR DESCRIPTION
**Card 9**
Adds a modal to show markdown syntax to help the users know how to write markdown and better understand where markdown is supported.
https://trello.com/c/ZozB05Eu
<img width="1602" alt="Screen Shot 2022-08-07 at 1 35 17 PM" src="https://user-images.githubusercontent.com/12549482/183308040-344bd44c-566b-4d11-838a-61bad9f48854.png">


**Card 10**
Adds a preview tab to the description textarea so the user can preview the markdown they are writing.
https://trello.com/c/n5hqVwrA
<img width="1607" alt="Screen Shot 2022-08-07 at 1 35 30 PM" src="https://user-images.githubusercontent.com/12549482/183308048-99be6383-f92e-4a06-afa7-b539bc4aa792.png">
