### PR TITLE
Small UI Tweaks

### DIFF
--- a/packages/nouns-webapp/src/components/IdeaCard/index.tsx
+++ b/packages/nouns-webapp/src/components/IdeaCard/index.tsx
@@ -91,9 +91,13 @@ const IdeaCard = ({
           </div>
           <div className="flex flex-row flex-1 justify-content-start align-items-center pt-2 pb-2">
             <span className="flex flex-1 font-bold text-sm text-[#8c8d92]">
-              {`${ens || shortAddress} | ${creatorLilNoun} lil nouns | ${moment(createdAt).format(
-                'MMM Do YYYY',
-              )} | ${_count?.comments || 0} comments`}
+              {`${ens || shortAddress} | ${
+                creatorLilNoun === 1 ? `${creatorLilNoun} lil noun` : `${creatorLilNoun} lil nouns`
+              } | ${moment(createdAt).format('MMM Do YYYY')} | ${
+                _count?.comments === 1
+                  ? `${_count?.comments} comment`
+                  : `${_count?.comments || 0} comments`
+              }`}
             </span>
             <span className="flex justify-self-end text-[#2b83f6] text-sm font-bold flex justify-end">
               <span

--- a/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
@@ -84,7 +84,7 @@ const CommentInput = ({
           className={`${
             hasNouns
               ? 'rounded-lg !bg-[#2B83F6] !text-white !font-bold'
-              : '!text-[#8C8D92] !bg-[#F4F4F8] !border-[#E2E3E8]-1 !font-bold'
+              : '!text-[#8C8D92] !bg-[#F4F4F8] !border-[#E2E3E8] !font-bold'
           } p-1 rounded`}
           onClick={() => {
             if (hasNouns && value.length > 0) {
@@ -241,6 +241,7 @@ const IdeaPage = () => {
                 nounBalance={nounBalance}
                 voteCount={idea.votecount}
                 votes={idea.votes}
+                withAvatars
               />
             </div>
           </div>

--- a/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/:id/index.tsx
@@ -264,9 +264,9 @@ const IdeaPage = () => {
         </div>
 
         <div className="flex flex-1 font-bold text-sm text-[#8c8d92] mt-12">
-          {`${ens || shortAddress} | ${creatorLilNoun} lil nouns | ${moment(idea.createdAt).format(
-            'MMM Do YYYY',
-          )}`}
+          {`${ens || shortAddress} | ${
+            creatorLilNoun === 1 ? `${creatorLilNoun} lil noun` : `${creatorLilNoun} lil nouns`
+          } | ${moment(idea.createdAt).format('MMM Do YYYY')}`}
         </div>
 
         <div className="mt-2 mb-2">

--- a/packages/nouns-webapp/src/pages/Ideas/Ideas.module.css
+++ b/packages/nouns-webapp/src/pages/Ideas/Ideas.module.css
@@ -37,6 +37,10 @@ p {
     margin-left: 0.5rem;
     margin-right: 0.5rem;
   }
+
+  .headerRow h1 {
+    font-size: 46px;
+  }
 }
 
 .wrapper {


### PR DESCRIPTION
Noticed a blue border on the disabled comment button on the staging site

<img width="477" alt="Screenshot 2022-08-08 at 22 06 41" src="https://user-images.githubusercontent.com/7782211/183514722-2773d0d6-3003-4266-ae5f-d770ca7168b3.png">


This PR also reduces the Idea title slightly on mobile devices and adds the voting avatars

<img width="552" alt="Screenshot 2022-08-08 at 22 07 29" src="https://user-images.githubusercontent.com/7782211/183514888-0182cdc4-0aa2-4646-83dc-9b7279f16e01.png">


Also fixing some content pluralisation