### PR TITLE
fix: limit voting direction value to 1 or -1

### DIFF
--- a/packages/nouns-api/src/services/ideas.ts
+++ b/packages/nouns-api/src/services/ideas.ts
@@ -163,6 +163,13 @@ class IdeasService {
       if (!user) {
         throw new Error('Failed to save vote: missing user details');
       }
+      const direction = Math.min(Math.max(parseInt(data.direction), -1), 1);
+
+      if (isNaN(direction) || direction === 0) {
+        // votes can only be 1 or -1 right now as we only support up or down votes
+        throw new Error('Failed to save vote: direction is not valid');
+      }
+
       const vote = prisma.vote.upsert({
         where: {
           ideaId_voterId: {
@@ -171,10 +178,10 @@ class IdeasService {
           },
         },
         update: {
-          direction: data.direction,
+          direction,
         },
         create: {
-          direction: data.direction,
+          direction,
           voterId: user.wallet,
           ideaId: data.ideaId,
         },


### PR DESCRIPTION
A community member managed to inflate their vote count by making api requests to the voting endpoint and changing the direction value. This PR should fix that by limiting the direction value to be either 1 or -1 when saving a vote.


The screenshot shows how the new logic will prevent this in the future

<img width="359" alt="Screenshot 2022-09-07 at 18 14 21" src="https://user-images.githubusercontent.com/7782211/188939405-ad4785a1-1b55-4777-8d19-9b672e12b9b3.png">
