### PR TITLE
Remove env var

### DIFF
--- a/packages/nouns-webapp/.env.example
+++ b/packages/nouns-webapp/.env.example
@@ -16,5 +16,3 @@ REACT_APP_IS_PRELAUNCH="true"
 
 # Nouns API endpoint for local testing
 REACT_APP_MAINNET_NOUNSAPI="http://localhost:5001"
-
-REACT_APP_PROP_LOT_BETA_ENABLED="true"

--- a/packages/nouns-webapp/src/config.ts
+++ b/packages/nouns-webapp/src/config.ts
@@ -148,7 +148,6 @@ const config = {
   app: app[CHAIN_ID],
   isPreLaunch: process.env.REACT_APP_IS_PRELAUNCH || 'false',
   addresses: getAddresses(),
-  isPropLotBetaEnabled: process.env.REACT_APP_PROP_LOT_BETA_ENABLED === 'true',
 };
 
 export default config;

--- a/packages/nouns-webapp/src/pages/Ideas/index.tsx
+++ b/packages/nouns-webapp/src/pages/Ideas/index.tsx
@@ -1,15 +1,10 @@
 import { Col, Row } from 'react-bootstrap';
 import Section from '../../layout/Section';
-import Ideas from '../../components/Ideas';
 import PropLotHome from '../../propLot/pages/PropLotHome';
-
-import config from '../../config';
 
 import classes from './Ideas.module.css';
 
 const IdeasPage = () => {
-  const isPropLotV2Enabled = config.isPropLotBetaEnabled;
-
   return (
     <Section fullWidth={false} className={classes.section}>
       <Col lg={10} className={classes.wrapper}>
@@ -17,7 +12,7 @@ const IdeasPage = () => {
           <span>Prop Lot</span>
           <h1>Submissions</h1>
         </Row>
-        {isPropLotV2Enabled ? <PropLotHome /> : <Ideas />}
+        <PropLotHome />
       </Col>
     </Section>
   );


### PR DESCRIPTION
Removing the `REACT_APP_PROP_LOT_BETA_ENABLED` env var. The intention was to use this almost as a feature flag but it feels unneccessary now. The API doesn't actually use this value either so the UI and API is a little out of sync when this isn't enabled anyway.