### PR TITLE
Th/onchain profile data (#50)

### DIFF
--- a/packages/nouns-webapp/src/components/Proposals/index.tsx
+++ b/packages/nouns-webapp/src/components/Proposals/index.tsx
@@ -113,6 +113,171 @@ export interface SnapshotProposal {
   [key: string]: any;
 }
 
+export const LilNounProposalRow = ({ proposal }: { proposal: Proposal }) => {
+  const currentBlock = useBlockNumber();
+
+  const isPropInStateToHaveCountDown =
+    proposal.status === ProposalState.PENDING ||
+    proposal.status === ProposalState.ACTIVE ||
+    proposal.status === ProposalState.QUEUED;
+
+  const countdownPill = (
+    <div className={classes.proposalStatusWrapper}>
+      <div className={clsx(proposalStatusClasses.proposalStatus, classes.countdownPill)}>
+        <div className={classes.countdownPillContentWrapper}>
+          <span className={classes.countdownPillClock}>
+            <ClockIcon height={16} width={16} />
+          </span>{' '}
+          <span className={classes.countdownPillText}>
+            {getCountdownCopy(proposal, currentBlock || 0)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <a
+      className={clsx(classes.proposalLink, classes.proposalLinkWithCountdown)}
+      href={`/vote/${proposal.id}`}
+      key={proposal.id}
+    >
+      <div className={classes.proposalInfoWrapper}>
+        <span className={classes.proposalTitle}>
+          <span className={classes.proposalId}>{proposal.id}</span> <span>{proposal.title}</span>
+        </span>
+
+        {isPropInStateToHaveCountDown && (
+          <div className={classes.desktopCountdownWrapper}>{countdownPill}</div>
+        )}
+        <div className={clsx(classes.proposalStatusWrapper, classes.votePillWrapper)}>
+          <ProposalStatus status={proposal.status}></ProposalStatus>
+        </div>
+      </div>
+
+      {isPropInStateToHaveCountDown && (
+        <div className={classes.mobileCountdownWrapper}>{countdownPill}</div>
+      )}
+    </a>
+  );
+};
+
+export const bigNounsPropStatus = (proposal: Proposal, snapshotVoteObject?: SnapshotProposal) => {
+  let propStatus = proposal.status;
+
+  if (snapshotVoteObject && !proposal.snapshotForCount) {
+    proposal.snapshotProposalId = snapshotVoteObject.id;
+
+    if (snapshotVoteObject.scores_total) {
+      const scores = snapshotVoteObject.scores;
+      proposal.snapshotForCount == scores[0];
+      proposal.snapshotAgainstCount == scores[1];
+      proposal.snapshotAbstainCount == scores[2];
+    }
+
+    switch (snapshotVoteObject.state) {
+      case 'active':
+        proposal.snapshotEnd = snapshotVoteObject.end;
+        if (proposal.status == ProposalState.PENDING || proposal.status == ProposalState.ACTIVE) {
+          propStatus = ProposalState.METAGOV_ACTIVE;
+        } else {
+          propStatus = proposal.status;
+        }
+
+        break;
+
+      case 'closed':
+        if (proposal.status == ProposalState.ACTIVE) {
+          propStatus = ProposalState.METAGOV_CLOSED;
+          break;
+        }
+        propStatus = proposal.status;
+        break;
+
+      case 'pending':
+        propStatus = ProposalState.PENDING;
+        break;
+
+      default:
+        propStatus = proposal.status;
+        break;
+    }
+  } else if (!snapshotVoteObject) {
+    if (proposal.status == ProposalState.ACTIVE) {
+      propStatus = ProposalState.METAGOV_PENDING;
+    } else {
+      propStatus = proposal.status;
+    }
+  }
+
+  return propStatus;
+};
+
+export const BigNounProposalRow = ({
+  proposal,
+  snapshotProposals,
+}: {
+  proposal: Proposal;
+  snapshotProposals: SnapshotProposal[];
+}) => {
+  const currentBlock = useBlockNumber();
+
+  const snapshotVoteObject = snapshotProposals.find(spi =>
+    spi.body.includes(proposal.transactionHash),
+  );
+
+  const propStatus = bigNounsPropStatus(proposal, snapshotVoteObject);
+
+  const isPropInStateToHaveCountDown =
+    propStatus === ProposalState.PENDING ||
+    propStatus === ProposalState.METAGOV_ACTIVE ||
+    propStatus === ProposalState.METAGOV_CLOSED ||
+    propStatus === ProposalState.ACTIVE ||
+    propStatus === ProposalState.QUEUED;
+
+  //if lil nouns vote is active, change countdown pill to reflect snapshot voting window
+
+  const countdownPill = (
+    <div className={classes.proposalStatusWrapper}>
+      <div className={clsx(proposalStatusClasses.proposalStatus, classes.countdownPill)}>
+        <div className={classes.countdownPillContentWrapper}>
+          <span className={classes.countdownPillClock}>
+            <ClockIcon height={16} width={16} />
+          </span>{' '}
+          <span className={classes.countdownPillText}>
+            {getCountdownCopy(proposal, currentBlock || 0, propStatus, snapshotVoteObject)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <a
+      className={clsx(classes.proposalLink, classes.proposalLinkWithCountdown)}
+      href={`/vote/nounsdao/${proposal.id}`}
+      key={proposal.id}
+    >
+      <div className={classes.proposalInfoWrapper}>
+        <span className={classes.proposalTitle}>
+          <span className={classes.proposalId}>{proposal.id}</span> <span>{proposal.title}</span>
+        </span>
+
+        {isPropInStateToHaveCountDown && (
+          <div className={classes.desktopCountdownWrapper}>{countdownPill}</div>
+        )}
+        <div className={clsx(classes.proposalStatusWrapper, classes.votePillWrapper)}>
+          <ProposalStatus status={propStatus}></ProposalStatus>
+        </div>
+      </div>
+
+      {isPropInStateToHaveCountDown && (
+        <div className={classes.mobileCountdownWrapper}>{countdownPill}</div>
+      )}
+    </a>
+  );
+};
+
 const Proposals = ({
   proposals,
   nounsDAOProposals,
@@ -219,54 +384,7 @@ const Proposals = ({
             proposals
               .slice(0)
               .reverse()
-              .map((p, i) => {
-                const isPropInStateToHaveCountDown =
-                  p.status === ProposalState.PENDING ||
-                  p.status === ProposalState.ACTIVE ||
-                  p.status === ProposalState.QUEUED;
-
-                const countdownPill = (
-                  <div className={classes.proposalStatusWrapper}>
-                    <div
-                      className={clsx(proposalStatusClasses.proposalStatus, classes.countdownPill)}
-                    >
-                      <div className={classes.countdownPillContentWrapper}>
-                        <span className={classes.countdownPillClock}>
-                          <ClockIcon height={16} width={16} />
-                        </span>{' '}
-                        <span className={classes.countdownPillText}>
-                          {getCountdownCopy(p, currentBlock || 0)}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                );
-
-                return (
-                  <a
-                    className={clsx(classes.proposalLink, classes.proposalLinkWithCountdown)}
-                    href={`/vote/${p.id}`}
-                    key={i}
-                  >
-                    <div className={classes.proposalInfoWrapper}>
-                      <span className={classes.proposalTitle}>
-                        <span className={classes.proposalId}>{p.id}</span> <span>{p.title}</span>
-                      </span>
-
-                      {isPropInStateToHaveCountDown && (
-                        <div className={classes.desktopCountdownWrapper}>{countdownPill}</div>
-                      )}
-                      <div className={clsx(classes.proposalStatusWrapper, classes.votePillWrapper)}>
-                        <ProposalStatus status={p.status}></ProposalStatus>
-                      </div>
-                    </div>
-
-                    {isPropInStateToHaveCountDown && (
-                      <div className={classes.mobileCountdownWrapper}>{countdownPill}</div>
-                    )}
-                  </a>
-                );
-              })
+              .map(p => <LilNounProposalRow proposal={p} key={p.id} />)
           ) : (
             <Alert variant="secondary">
               <Alert.Heading>No proposals found</Alert.Heading>
@@ -289,109 +407,9 @@ const Proposals = ({
             nounsDAOProposals
               .slice(0)
               .reverse()
-              .map((p, i) => {
-                const snapshotVoteObject = snapshotProposals.find(spi =>
-                  spi.body.includes(p.transactionHash),
-                );
-
-                let propStatus = p.status;
-
-                if (snapshotVoteObject && !p.snapshotForCount) {
-                  p.snapshotProposalId = snapshotVoteObject.id;
-
-                  if (snapshotVoteObject.scores_total) {
-                    const scores = snapshotVoteObject.scores;
-                    p.snapshotForCount == scores[0];
-                    p.snapshotAgainstCount == scores[1];
-                    p.snapshotAbstainCount == scores[2];
-                  }
-
-                  switch (snapshotVoteObject.state) {
-                    case 'active':
-                      p.snapshotEnd = snapshotVoteObject.end;
-                      if (p.status == ProposalState.PENDING || p.status == ProposalState.ACTIVE) {
-                        propStatus = ProposalState.METAGOV_ACTIVE;
-                      } else {
-                        propStatus = p.status;
-                      }
-
-                      break;
-
-                    case 'closed':
-                      if (p.status == ProposalState.ACTIVE) {
-                        propStatus = ProposalState.METAGOV_CLOSED;
-                        break;
-                      }
-                      propStatus = p.status;
-                      break;
-
-                    case 'pending':
-                      propStatus = ProposalState.PENDING;
-                      break;
-
-                    default:
-                      propStatus = p.status;
-                      break;
-                  }
-                } else if (!snapshotVoteObject) {
-                  if (p.status == ProposalState.ACTIVE) {
-                    propStatus = ProposalState.METAGOV_PENDING;
-                  } else {
-                    propStatus = p.status;
-                  }
-                }
-
-                const isPropInStateToHaveCountDown =
-                  propStatus === ProposalState.PENDING ||
-                  propStatus === ProposalState.METAGOV_ACTIVE ||
-                  propStatus === ProposalState.METAGOV_CLOSED ||
-                  propStatus === ProposalState.ACTIVE ||
-                  propStatus === ProposalState.QUEUED;
-
-                //if lil nouns vote is active, change countdown pill to reflect snapshot voting window
-
-                const countdownPill = (
-                  <div className={classes.proposalStatusWrapper}>
-                    <div
-                      className={clsx(proposalStatusClasses.proposalStatus, classes.countdownPill)}
-                    >
-                      <div className={classes.countdownPillContentWrapper}>
-                        <span className={classes.countdownPillClock}>
-                          <ClockIcon height={16} width={16} />
-                        </span>{' '}
-                        <span className={classes.countdownPillText}>
-                          {getCountdownCopy(p, currentBlock || 0, propStatus, snapshotVoteObject)}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                );
-
-                return (
-                  <a
-                    className={clsx(classes.proposalLink, classes.proposalLinkWithCountdown)}
-                    href={`/vote/nounsdao/${p.id}`}
-                    key={i}
-                  >
-                    <div className={classes.proposalInfoWrapper}>
-                      <span className={classes.proposalTitle}>
-                        <span className={classes.proposalId}>{p.id}</span> <span>{p.title}</span>
-                      </span>
-
-                      {isPropInStateToHaveCountDown && (
-                        <div className={classes.desktopCountdownWrapper}>{countdownPill}</div>
-                      )}
-                      <div className={clsx(classes.proposalStatusWrapper, classes.votePillWrapper)}>
-                        <ProposalStatus status={propStatus}></ProposalStatus>
-                      </div>
-                    </div>
-
-                    {isPropInStateToHaveCountDown && (
-                      <div className={classes.mobileCountdownWrapper}>{countdownPill}</div>
-                    )}
-                  </a>
-                );
-              })
+              .map(p => (
+                <BigNounProposalRow proposal={p} snapshotProposals={snapshotProposals} key={p.id} />
+              ))
           ) : (
             <Alert variant="secondary">
               <Alert.Heading>No proposals found</Alert.Heading>

--- a/packages/nouns-webapp/src/propLot/components/ProfileGovernanceList/index.tsx
+++ b/packages/nouns-webapp/src/propLot/components/ProfileGovernanceList/index.tsx
@@ -1,0 +1,238 @@
+import { Spinner, Alert } from 'react-bootstrap';
+import { useHistory } from 'react-router-dom';
+
+import { ProposalState } from '../../../wrappers/nounsDao';
+import { bigNounsPropStatus } from '../../../components/Proposals';
+import { useState } from 'react';
+import { TabOption, TabWrapper } from '../ProfileTabFilters';
+import ProposalStatus from '../../../components/ProposalStatus';
+import { TabFilterOptions, TabFilterOptionValues } from '../../hooks/useProfileGovernanceData';
+
+import { createBreakpoint } from 'react-use';
+import DropdownFilter from '../DropdownFilter';
+import { FilterType as FilterTypeEnum } from '../../graphql/__generated__/globalTypes';
+
+const useBreakpoint = createBreakpoint({ XL: 1440, L: 940, M: 650, S: 540 });
+
+const sortFilter: any = {
+  __typename: 'PropLotFilter',
+  id: 'GovernanceFilter',
+  type: FilterTypeEnum.SINGLE_SELECT,
+  label: 'Filter',
+  options: [
+    {
+      id: `ALL`,
+      selected: false,
+      value: 'ALL',
+      label: 'All',
+    },
+    {
+      id: `LIL_NOUNS`,
+      selected: false,
+      value: 'LIL_NOUN',
+      label: 'Lil Nouns DAO',
+    },
+    {
+      id: `NOUNS`,
+      selected: false,
+      value: 'BIG_NOUN',
+      label: 'Nouns DAO',
+    },
+  ],
+};
+
+const ProposalWrapper = ({
+  id,
+  title,
+  status,
+  type,
+  children,
+}: {
+  id: number;
+  title: string;
+  status?: ProposalState;
+  type: string;
+  children: any;
+}) => {
+  const breakpoint = useBreakpoint();
+  const isMobile = breakpoint === 'S';
+  const history = useHistory();
+  const onClick = () => {
+    type === 'LIL_NOUN' ? history.push(`/vote/${id}`) : history.push(`/vote/nounsdao/${id}`);
+  };
+
+  const mobileRow = (
+    <div
+      onClick={onClick}
+      className="flex flex-col border border-[#e2e3e8] rounded-lg cursor-pointer pt-[24px] pb-[24px] px-3"
+    >
+      <div className="font-propLot font-bold text-[18px] flex flex-row flex-1 justify-content-between align-items-start">
+        <span className="flex flex-col sm:flex-row text-[#8C8D92] overflow-hidden gap-[8px]">
+          <span className="flex flex-row gap-[8px] flex-1 justify-content-start align-items-start">
+            <span>{id}</span>
+            <span className="truncate">{type === 'LIL_NOUN' ? 'Lil Nouns DAO' : 'Nouns DAO'}</span>
+          </span>
+          <div className="flex flex-row flex-1 justify-content-start align-items-start">
+            <span className="font-bold text-[18px] text-[#212529] flex flex-1">{title}</span>
+          </div>
+        </span>
+        <div className="flex justify-self-end">
+          <ProposalStatus status={status}></ProposalStatus>
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+
+  const desktopRow = (
+    <div
+      onClick={onClick}
+      className="flex flex-col border border-[#e2e3e8] rounded-lg cursor-pointer pt-[24px] pb-[24px] px-3"
+    >
+      <div className="font-propLot font-bold text-[18px] flex flex-row flex-1 justify-content-start align-items-start">
+        <div className="flex flex-1 flex-col">
+          <div className="flex flex-1 gap-[8px]">
+            <span className="flex text-[#8C8D92] gap-[8px] overflow-hidden">
+              <span>{id}</span>
+              <span className="truncate">
+                {type === 'LIL_NOUN' ? 'Lil Nouns DAO' : 'Nouns DAO'}
+              </span>
+            </span>
+            <span className="text-[#212529] flex flex-1">{title}</span>
+          </div>
+        </div>
+        <div className="flex justify-self-end">
+          <ProposalStatus status={status}></ProposalStatus>
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+
+  return isMobile ? mobileRow : desktopRow;
+};
+
+const filterProposals = (proposals: any[], currentFilter: string) =>
+  proposals
+    .filter(proposal => {
+      if (currentFilter === 'ALL') {
+        return true;
+      }
+      return proposal.type === currentFilter;
+    })
+    .sort((a: any, b: any) => b.createdAt - a.createdAt) || [];
+
+const ProfileGovernanceList = ({
+  isLoadingGovernance,
+  snapshotProposalData,
+  categorisedProposals,
+}: {
+  isLoadingGovernance: boolean;
+  snapshotProposalData: any;
+  categorisedProposals: { [key in TabFilterOptionValues]: any[] };
+}) => {
+  const [currentTab, setCurrentTab] = useState(TabFilterOptionValues.YES);
+  const [currentFilter, setFilter] = useState('ALL');
+
+  if (isLoadingGovernance) {
+    return (
+      <div className="flex flex-1 justify-center mt-[18px]">
+        <Spinner animation="border" />
+      </div>
+    );
+  }
+
+  const sortedProposals = filterProposals(categorisedProposals[currentTab] || [], currentFilter);
+
+  return (
+    <>
+      <div className="mt-[32px] mb-[24px] flex flex-col-reverse sm:flex-row">
+        <div className="flex mb-[16px] sm:mt-0 mt-[16px] sm:mb-0">
+          <TabWrapper>
+            {TabFilterOptions.map(({ id, label }: { id: TabFilterOptionValues; label: string }) => {
+              return (
+                <TabOption
+                  id={id}
+                  isSelected={currentTab === id}
+                  onClick={e => {
+                    e.preventDefault();
+                    setCurrentTab(id);
+                  }}
+                >{`${label} ${
+                  categorisedProposals[id]?.filter(proposal => {
+                    if (currentFilter === 'ALL') {
+                      return true;
+                    }
+                    return proposal.type === currentFilter;
+                  }).length || 0
+                }`}</TabOption>
+              );
+            })}
+          </TabWrapper>
+        </div>
+        <div className="flex flex-1 justify-end">
+          <DropdownFilter
+            filter={sortFilter}
+            updateFilters={(filters: string[]) => {
+              setFilter(filters[0]);
+            }}
+          />
+        </div>
+      </div>
+      {sortedProposals?.map(p => {
+        if (p.type === 'LIL_NOUN') {
+          return (
+            <div className="mb-[16px] space-y-4" key={p.proposal.id}>
+              <ProposalWrapper
+                id={p.proposal.id}
+                title={p.proposal.title}
+                status={p.proposal.status}
+                type={p.type}
+                key={p.proposal.id}
+              >
+                <div className="flex flex-row flex-1 justify-content-start align-items-center pt-[12px] pt-[12px]">
+                  <span className="font-propLot text-[16px] text-[#212529] border border-[#e2e3e8] bg-[#F4F4F8] p-4 rounded-lg flex-1">
+                    {p.reason || 'No reason given'}
+                  </span>
+                </div>
+              </ProposalWrapper>
+            </div>
+          );
+        }
+
+        if (p.type === 'BIG_NOUN') {
+          const snapshotVoteObject = snapshotProposalData.find((spi: any) =>
+            spi.body.includes(p.transactionHash),
+          );
+          const propStatus = bigNounsPropStatus(p.proposal, snapshotVoteObject);
+          return (
+            <div className="mb-[16px] space-y-4" key={p.proposal.id}>
+              <ProposalWrapper
+                id={p.proposal.id}
+                title={p.proposal.title}
+                status={propStatus}
+                type={p.type}
+                key={p.proposal.id}
+              >
+                <div className="flex flex-row flex-1 justify-content-start align-items-center pt-[12px] pt-[12px]">
+                  <span className="font-propLot text-[16px] text-[#212529] border border-[#e2e3e8] bg-[#F4F4F8] p-4 rounded-lg flex-1">
+                    {p.reason || 'No reason given'}
+                  </span>
+                </div>
+              </ProposalWrapper>
+            </div>
+          );
+        }
+
+        return null;
+      })}
+      {!Boolean(sortedProposals.length) && (
+        <Alert variant="secondary">
+          <Alert.Heading>No data found.</Alert.Heading>
+          <p>We couldn't find any data for this user!</p>
+        </Alert>
+      )}
+    </>
+  );
+};
+export default ProfileGovernanceList;

--- a/packages/nouns-webapp/src/propLot/components/ProfileTabFilters/index.tsx
+++ b/packages/nouns-webapp/src/propLot/components/ProfileTabFilters/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, forwardRef } from 'react';
+import { useEffect, useState, forwardRef, ReactNode, MouseEvent } from 'react';
 import { buildSelectedFilters, updateSelectedFilters } from '../../utils/queryFilterHelpers';
 
 import {
@@ -9,9 +9,59 @@ import {
   getPropLot_propLot_dateFilter as DateFilter,
   getPropLot_propLot_dateFilter_options as DateFilterOptions,
 } from '../../graphql/__generated__/getPropLot';
+import { FilterType } from '../../graphql/__generated__/globalTypes';
+
+export type GenericFilter = {
+  id: string;
+  type: FilterType;
+  label: string | null;
+  __typename: 'PropLotFilter';
+  options: {
+    id: string;
+    label: string | null;
+    selected: boolean;
+    value: string;
+    icon: string | null;
+    __typename: 'FilterOption';
+  }[];
+};
 
 type Filter = TagFilter | SortFilter | DateFilter;
 type FilterOptions = TagFilterOptions | SortFilterOptions | DateFilterOptions;
+
+export const TabWrapper = ({ children }: { children: ReactNode }) => {
+  return (
+    <div className="flex flex-1 flex-row items-center overflow-scroll pt-[8px] gap-[16px]">
+      {children}
+    </div>
+  );
+};
+
+export const TabOption = ({
+  id,
+  isSelected,
+  onClick,
+  children,
+}: {
+  id: string;
+  isSelected: boolean;
+  onClick: (e: MouseEvent) => void;
+  children: ReactNode;
+}) => {
+  return (
+    <div
+      onClick={onClick}
+      key={id}
+      className={`${
+        isSelected
+          ? 'text-[#2B83F6] underline underline-offset-8 decoration-2'
+          : 'hover:text-[#2B83F6] pb-[6px]'
+      } whitespace-nowrap cursor-pointer text-[#8C8D92] flex-1 sm:flex-none font-semibold font-propLot pb-[2px]`}
+    >
+      {children}
+    </div>
+  );
+};
 
 const ProfileTabFilters = ({
   filter,
@@ -34,27 +84,23 @@ const ProfileTabFilters = ({
   };
 
   return (
-    <div className="flex flex-1 flex-row items-center overflow-scroll pt-[8px] gap-[16px]">
+    <TabWrapper>
       {filter.options.map(opt => {
         const isSelected = selectedFilters.some(selectedFilter => selectedFilter === opt.value);
         return (
-          <div
-            onClick={evt => {
-              evt.preventDefault();
+          <TabOption
+            id={opt.id}
+            isSelected={isSelected}
+            onClick={(e: MouseEvent) => {
+              e.preventDefault();
               handleUpdateFilters(opt, isSelected);
             }}
-            key={opt.id}
-            className={`${
-              isSelected
-                ? 'text-[#2B83F6] underline underline-offset-8 decoration-2'
-                : 'hover:text-[#2B83F6] pb-[6px]'
-            } whitespace-nowrap cursor-pointer text-[#8C8D92] flex-1 sm:flex-none font-semibold font-propLot pb-[2px]`}
           >
             {opt.label}
-          </div>
+          </TabOption>
         );
       })}
-    </div>
+    </TabWrapper>
   );
 };
 

--- a/packages/nouns-webapp/src/propLot/hooks/useProfileGovernanceData.ts
+++ b/packages/nouns-webapp/src/propLot/hooks/useProfileGovernanceData.ts
@@ -1,0 +1,195 @@
+import { formatSubgraphProposal } from '../../wrappers/nounsDao';
+import { formatBigNounSubgraphProposal } from '../../wrappers/bigNounsDao';
+import { useLazyQuery } from '@apollo/client';
+import { useEffect, useRef, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+
+import {
+  LIL_NOUNS_GOVERNANCE_BY_OWNER_SUB,
+  SNAPSHOT_GOVERNANCE_BY_OWNER_SUB,
+  BIG_NOUNS_PROPOSALS_SUB,
+} from '../../wrappers/subgraph';
+import { useBlockMeta, useBlockNumber } from '@usedapp/core';
+import { useBlockTimestamp } from '../../hooks/useBlockTimestamp';
+
+export enum TabFilterOptionValues {
+  YES = 'Yes',
+  NO = 'NO',
+  ABSTAINED = 'ABSTAINED',
+  SUBMITTED = 'SUBMITTED',
+}
+
+export const TabFilterOptions: any[] = [
+  {
+    label: 'Voted Yes',
+    id: TabFilterOptionValues.YES,
+  },
+  {
+    id: TabFilterOptionValues.NO,
+    label: 'Voted No',
+  },
+  {
+    id: TabFilterOptionValues.ABSTAINED,
+    label: 'Abstained',
+  },
+  {
+    id: TabFilterOptionValues.SUBMITTED,
+    label: 'Submitted',
+  },
+];
+
+const buildInitialCategorisedProposalState = () => {
+  return Object.keys(TabFilterOptionValues).reduce((prev, curr) => {
+    return {
+      ...prev,
+      [curr]: [],
+    };
+  }, {} as { [key in TabFilterOptionValues]: any[] });
+};
+const useProfileGovernanceData = () => {
+  const { id } = useParams() as { id: string };
+  const snapshotProposalVoteMap = useRef(
+    {} as { [key: string]: { voted: number; reason: string } },
+  );
+  const blockNumber = useBlockNumber();
+  const bigNounsTimestamp = useBlockTimestamp(blockNumber);
+  const { timestamp } = useBlockMeta();
+
+  const [
+    getLilNounGovernanceHistory,
+    { data: lilNounGovernanceHistory, loading: loadingLilNounsHistory },
+  ] = useLazyQuery(LIL_NOUNS_GOVERNANCE_BY_OWNER_SUB, {
+    context: {
+      clientName: 'LilNouns',
+    },
+  });
+
+  const [getBigNounProposalData, { data: bigNounProposalData, loading: loadingBigNounsHistory }] =
+    useLazyQuery(BIG_NOUNS_PROPOSALS_SUB, {
+      context: {
+        clientName: 'NounsDAO',
+      },
+    });
+
+  const [getNounsSnapshotHistory, { data: nounsSnapshotHistory, loading: loadingSnapshot }] =
+    useLazyQuery(SNAPSHOT_GOVERNANCE_BY_OWNER_SUB, {
+      context: {
+        clientName: 'NounsDAOSnapshot',
+      },
+      onCompleted: data => {
+        const snapshotProposalData =
+          data?.votes.map((vote: any) => {
+            return { choice: vote.choice, reason: vote.reason, body: vote.proposal.body };
+          }) || [];
+        const proposalUrlRegex = /nouns.wtf\/vote\/[[0-9]+/;
+
+        const snapshotProposalIds = snapshotProposalData
+          .map((proposal: any) => {
+            const matchedUrl = proposal.body.match(proposalUrlRegex);
+            if (Boolean(matchedUrl?.length)) {
+              const proposalId = matchedUrl[0].match(/[0-9]+/);
+              const choice: number = proposal.choice;
+              snapshotProposalVoteMap.current[proposalId] = {
+                voted: choice,
+                reason: proposal.reason || '',
+              };
+              return proposalId[0];
+            }
+            return null;
+          })
+          .filter(Boolean);
+
+        if (Boolean(snapshotProposalIds.length)) {
+          getBigNounProposalData({
+            variables: {
+              ids: snapshotProposalIds,
+            },
+          });
+        }
+      },
+    });
+
+  useEffect(() => {
+    getLilNounGovernanceHistory({
+      variables: {
+        id: id.toLowerCase(),
+      },
+    });
+
+    getNounsSnapshotHistory({
+      variables: {
+        id: id.toLowerCase(),
+      },
+    });
+  }, [id]);
+
+  const snapshotProposalData = nounsSnapshotHistory?.votes.map((vote: any) => vote.proposal) || [];
+
+  const lilNounProposals = useMemo(() => {
+    return (
+      lilNounGovernanceHistory?.votes.map((vote: any) => {
+        const proposal = formatSubgraphProposal(vote.proposal, blockNumber, timestamp);
+        return {
+          type: 'LIL_NOUN',
+          proposal,
+          createdAt: proposal.createdBlock,
+          voted: vote.supportDetailed,
+          reason: vote.reason || '',
+        };
+      }) || []
+    );
+  }, [lilNounGovernanceHistory]);
+
+  const bigNounProposals = useMemo(() => {
+    return (
+      bigNounProposalData?.proposals.map((p: any) => {
+        const proposal = formatBigNounSubgraphProposal(p, blockNumber, bigNounsTimestamp);
+        return {
+          type: 'BIG_NOUN',
+          proposal,
+          createdAt: proposal.createdBlock,
+          voted: snapshotProposalVoteMap.current[proposal.id]?.voted,
+          reason: snapshotProposalVoteMap.current[proposal.id]?.reason,
+        };
+      }) || []
+    );
+  }, [bigNounProposalData, snapshotProposalVoteMap]);
+
+  const categorisedProposals = useMemo(() => {
+    return [...lilNounProposals, ...bigNounProposals].reduce((acc, curr) => {
+      if (curr.voted === 1) {
+        acc[TabFilterOptionValues.YES] = [...(acc[TabFilterOptionValues.YES] || []), curr];
+      }
+
+      if (curr.voted === 0) {
+        acc[TabFilterOptionValues.NO] = [...(acc[TabFilterOptionValues.NO] || []), curr];
+      }
+
+      if (curr.voted === 2) {
+        acc[TabFilterOptionValues.ABSTAINED] = [
+          ...(acc[TabFilterOptionValues.ABSTAINED] || []),
+          curr,
+        ];
+      }
+
+      if (curr.proposal.proposer === id) {
+        acc[TabFilterOptionValues.SUBMITTED] = [
+          ...(acc[TabFilterOptionValues.SUBMITTED] || []),
+          curr,
+        ];
+      }
+
+      return acc;
+    }, buildInitialCategorisedProposalState());
+  }, [lilNounProposals, bigNounProposals]);
+
+  return {
+    isLoading: loadingLilNounsHistory || loadingSnapshot || loadingBigNounsHistory,
+    lilNounProposals,
+    bigNounProposals,
+    snapshotProposalData,
+    categorisedProposals,
+  };
+};
+
+export default useProfileGovernanceData;

--- a/packages/nouns-webapp/src/propLot/pages/PropLotUserProfile.tsx
+++ b/packages/nouns-webapp/src/propLot/pages/PropLotUserProfile.tsx
@@ -1,4 +1,4 @@
-import { Col, Row } from 'react-bootstrap';
+import { Col, Row, Button, Spinner } from 'react-bootstrap';
 import Section from '../../layout/Section';
 import { v4 } from 'uuid';
 import { Alert } from 'react-bootstrap';
@@ -8,7 +8,7 @@ import { useParams } from 'react-router-dom';
 
 import Davatar from '@davatar/react';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useAccountVotes, useNounTokenBalance } from '../../wrappers/nounToken';
 import { useAuth } from '../../hooks/useAuth';
 import { useLazyQuery } from '@apollo/client';
@@ -28,12 +28,23 @@ import { StandaloneNounCircular } from '../../components/StandaloneNoun';
 import { GrayCircle } from '../../components/GrayCircle';
 import { NOUNS_BY_OWNER_SUB } from '../../wrappers/subgraph';
 import ProfileCommentRow from '../components/ProfileCommentRow';
+import ProfileGovernanceList from '../components/ProfileGovernanceList';
 
-const ProfileCard = (props: { title: string; count: number }) => {
+import useProfileGovernanceData, { TabFilterOptionValues } from '../hooks/useProfileGovernanceData';
+
+const ProfileCard = (props: { title: string; count: number; isLoading?: boolean }) => {
   return (
     <div className="font-propLot whitespace-nowrap py-[8px] px-[16px] gap-[4px] sm:p-[16px] sm:gap-[8px] bg-white border-solid border border-[#e2e3e8] rounded-[16px] box-border flex flex-1 flex-col justify-start">
-      <span className="font-semibold text-[12px] text-[#8C8D92]">{props.title}</span>
-      <span className="font-extrabold text-[24px] text-[#212529]">{props.count}</span>
+      {props.isLoading ? (
+        <div className="flex flex-1 justify-center mt-[18px]">
+          <Spinner animation="border" />
+        </div>
+      ) : (
+        <>
+          <span className="font-semibold text-[12px] text-[#8C8D92]">{props.title}</span>
+          <span className="font-extrabold text-[24px] text-[#212529]">{props.count}</span>
+        </>
+      )}
     </div>
   );
 };
@@ -113,6 +124,11 @@ const PropLotUserProfile = () => {
   const { id } = useParams() as { id: string };
   const { account } = useEthers();
   const { getAuthHeader } = useAuth();
+  const {
+    isLoading: isLoadingGovernance,
+    snapshotProposalData,
+    categorisedProposals,
+  } = useProfileGovernanceData();
 
   const [getPropLotProfileQuery, { data, refetch }] = useLazyQuery<getPropLotProfile>(
     GET_PROPLOT_PROFILE_QUERY,
@@ -180,6 +196,17 @@ const PropLotUserProfile = () => {
     refetch({ options: { wallet: id, requestUUID: v4(), filters: selectedfilters } });
   };
 
+  const [listButtonActive, setListButtonActive] = useState('PROP_LOT');
+
+  const lists: { [key: string]: any } = {
+    PROP_LOT: {
+      title: 'Prop Lot',
+    },
+    GOVERNANCE: {
+      title: 'Governance',
+    },
+  };
+
   const nounBalanceWithDelegates = useAccountVotes(id || undefined) ?? 0;
   const nounWalletBalance = useNounTokenBalance(id ?? '') ?? 0;
 
@@ -187,6 +214,13 @@ const PropLotUserProfile = () => {
 
   const ens = useReverseENSLookUp(id);
   const shortAddress = useShortAddress(id);
+  const calculateOnchainVotes = () => {
+    const yesVotes = categorisedProposals[TabFilterOptionValues.YES]?.length || 0;
+    const noVotes = categorisedProposals[TabFilterOptionValues.NO]?.length || 0;
+    const abstainedVotes = categorisedProposals[TabFilterOptionValues.ABSTAINED]?.length || 0;
+
+    return yesVotes + noVotes + abstainedVotes;
+  };
 
   const buildProfileCards = (userStats: UserStats) => {
     return (
@@ -195,6 +229,16 @@ const PropLotUserProfile = () => {
         <ProfileCard count={userStats.upvotesReceived || 0} title={'Upvotes received'} />
         <ProfileCard count={userStats.downvotesReceived || 0} title={'Downvotes received'} />
         <ProfileCard count={userStats.netVotesReceived || 0} title={'Net votes'} />
+        <ProfileCard
+          count={categorisedProposals[TabFilterOptionValues.SUBMITTED]?.length || 0}
+          title={'On-chain proposals'}
+          isLoading={isLoadingGovernance}
+        />
+        <ProfileCard
+          count={calculateOnchainVotes()}
+          title={'On-chain votes cast'}
+          isLoading={isLoadingGovernance}
+        />
       </>
     );
   };
@@ -228,58 +272,124 @@ const PropLotUserProfile = () => {
               buildProfileCards(data?.propLotProfile?.profile.user.userStats)}
           </div>
 
-          <h2 className="font-londrina text-[38px] text-[#212529] font-normal mt-[48px] sm:mt-[81px]">
-            Prop Lot activity
-          </h2>
-
-          <div className="mt-[32px] mb-[24px] flex flex-col-reverse sm:flex-row">
-            <div className="flex mb-[16px] sm:mt-0 mt-[16px] sm:mb-0">
-              {data?.propLotProfile?.tabFilter && (
-                <ProfileTabFilters
-                  filter={data.propLotProfile.tabFilter}
-                  updateFilters={handleUpdateFilters}
-                />
-              )}
-            </div>
-            <div className="flex flex-1 justify-end">
-              {data?.propLotProfile?.sortFilter && (
-                <DropdownFilter
-                  filter={data.propLotProfile.sortFilter}
-                  updateFilters={handleUpdateFilters}
-                />
-              )}
-            </div>
-          </div>
-
-          {data?.propLotProfile?.list?.map(listItem => {
-            if (listItem.__typename === 'Idea') {
-              return (
-                <div className="mb-[16px] space-y-4">
-                  <IdeaRow
-                    idea={listItem}
-                    key={`idea-${listItem.id}`}
-                    nounBalance={nounBalanceWithDelegates}
-                    disableControls={isAccountOwner}
-                  />
+          {listButtonActive === 'GOVERNANCE' && (
+            <>
+              <div className="mt-[48px] sm:mt-[81px] flex flex-1 items-center flex-col-reverse gap-[16px] sm:gap-[8px] sm:flex-row">
+                <h2 className="font-londrina text-[38px] text-[#212529] font-normal flex flex-1">
+                  Governance activity
+                </h2>
+                <div
+                  className="flex flex-wrap justify-center !gap-[8px]"
+                  role="btn-toolbar"
+                  aria-label="Basic example"
+                >
+                  {Object.keys(lists).map(list => {
+                    return (
+                      <Button
+                        key={list}
+                        className={`!border-box !flex !flex-row justify-center items-center !py-[8px] !px-[12px] !bg-white !border !rounded-[100px] ${
+                          listButtonActive === list
+                            ? '!text-[#212529] !border-[#2B83F6] !border-[2px]'
+                            : '!text-[#8C8D92] !border-[#E2E3E8] !border-[1px]'
+                        } !text-[16px] !font-semibold`}
+                        id={list}
+                        onClick={e => setListButtonActive(list)}
+                      >
+                        {lists[list].title}
+                      </Button>
+                    );
+                  })}
                 </div>
-              );
-            }
+              </div>
+              <ProfileGovernanceList
+                isLoadingGovernance={isLoadingGovernance}
+                snapshotProposalData={snapshotProposalData}
+                categorisedProposals={categorisedProposals}
+              />
+            </>
+          )}
 
-            if (listItem.__typename === 'Comment') {
-              return (
-                <div className="mb-[16px] space-y-4">
-                  <ProfileCommentRow key={`comment-${listItem.id}`} comment={listItem} />
+          {listButtonActive === 'PROP_LOT' && (
+            <>
+              <div className="mt-[48px] sm:mt-[81px] flex flex-1 items-center flex-col-reverse gap-[16px] sm:gap-[8px] sm:flex-row">
+                <h2 className="font-londrina text-[38px] text-[#212529] font-normal flex flex-1">
+                  Prop Lot activity
+                </h2>
+
+                <div
+                  className="flex flex-wrap justify-center !gap-[8px]"
+                  role="btn-toolbar"
+                  aria-label="Basic example"
+                >
+                  {Object.keys(lists).map(list => {
+                    return (
+                      <Button
+                        key={list}
+                        className={`!border-box !flex !flex-row justify-center items-center !py-[8px] !px-[12px] !bg-white !border !rounded-[100px] ${
+                          listButtonActive === list
+                            ? '!text-[#212529] !border-[#2B83F6] !border-[2px]'
+                            : '!text-[#8C8D92] !border-[#E2E3E8] !border-[1px]'
+                        } !text-[16px] !font-semibold`}
+                        id={list}
+                        onClick={e => setListButtonActive(list)}
+                      >
+                        {lists[list].title}
+                      </Button>
+                    );
+                  })}
                 </div>
-              );
-            }
+              </div>
 
-            return null;
-          })}
-          {!Boolean(data?.propLotProfile?.list?.length) && (
-            <Alert variant="secondary">
-              <Alert.Heading>No data found.</Alert.Heading>
-              <p>We couldn't find any data for this user!</p>
-            </Alert>
+              <div className="mt-[32px] mb-[24px] flex flex-col-reverse sm:flex-row">
+                <div className="flex mb-[16px] sm:mt-0 mt-[16px] sm:mb-0">
+                  {data?.propLotProfile?.tabFilter && (
+                    <ProfileTabFilters
+                      filter={data.propLotProfile.tabFilter}
+                      updateFilters={handleUpdateFilters}
+                    />
+                  )}
+                </div>
+                <div className="flex flex-1 justify-end">
+                  {data?.propLotProfile?.sortFilter && (
+                    <DropdownFilter
+                      filter={data.propLotProfile.sortFilter}
+                      updateFilters={handleUpdateFilters}
+                    />
+                  )}
+                </div>
+              </div>
+
+              {data?.propLotProfile?.list?.map(listItem => {
+                if (listItem.__typename === 'Idea') {
+                  return (
+                    <div className="mb-[16px] space-y-4">
+                      <IdeaRow
+                        idea={listItem}
+                        key={`idea-${listItem.id}`}
+                        nounBalance={nounBalanceWithDelegates}
+                        disableControls={isAccountOwner}
+                      />
+                    </div>
+                  );
+                }
+
+                if (listItem.__typename === 'Comment') {
+                  return (
+                    <div className="mb-[16px] space-y-4">
+                      <ProfileCommentRow key={`comment-${listItem.id}`} comment={listItem} />
+                    </div>
+                  );
+                }
+
+                return null;
+              })}
+              {!Boolean(data?.propLotProfile?.list?.length) && (
+                <Alert variant="secondary">
+                  <Alert.Heading>No data found.</Alert.Heading>
+                  <p>We couldn't find any data for this user!</p>
+                </Alert>
+              )}
+            </>
           )}
         </div>
       </Col>

--- a/packages/nouns-webapp/src/propLot/utils/queryFilterHelpers.ts
+++ b/packages/nouns-webapp/src/propLot/utils/queryFilterHelpers.ts
@@ -7,7 +7,7 @@ import {
   getPropLot_propLot_dateFilter_options as DateFilterOptions,
 } from '../graphql/__generated__/getPropLot';
 
-import { FilterType as FilterTyeEnum } from '../graphql/__generated__/globalTypes';
+import { FilterType as FilterTypeEnum } from '../graphql/__generated__/globalTypes';
 
 type Filter = TagFilter | SortFilter | DateFilter;
 type FilterOptions = TagFilterOptions | SortFilterOptions | DateFilterOptions;
@@ -35,7 +35,7 @@ export const updateSelectedFilters = (
   isSelected: boolean,
 ) => {
   let newFilters = [...selectedFilters];
-  if (filter.type === FilterTyeEnum.SINGLE_SELECT) {
+  if (filter.type === FilterTypeEnum.SINGLE_SELECT) {
     if (isSelected) {
       newFilters = selectedFilters.filter(selectedFilter => selectedFilter !== opt.value);
     } else {
@@ -43,7 +43,7 @@ export const updateSelectedFilters = (
     }
   }
 
-  if (filter.type === FilterTyeEnum.MULTI_SELECT) {
+  if (filter.type === FilterTypeEnum.MULTI_SELECT) {
     if (isSelected) {
       newFilters = selectedFilters.filter(selectedFilter => selectedFilter !== opt.value);
     } else {

--- a/packages/nouns-webapp/src/wrappers/subgraph.ts
+++ b/packages/nouns-webapp/src/wrappers/subgraph.ts
@@ -510,6 +510,168 @@ export const NOUNS_BY_OWNER_SUB = gql`
   }
 `;
 
+export const LIL_NOUNS_GOVERNANCE_BY_OWNER_SUB = gql`
+  query governanceProfile($id: String!) {
+    votes(where: { voter: $id }) {
+      proposal {
+        id
+        description
+        status
+        proposalThreshold
+        quorumVotes
+        forVotes
+        againstVotes
+        abstainVotes
+        createdTransactionHash
+        createdBlock
+        startBlock
+        endBlock
+        executionETA
+        targets
+        values
+        signatures
+        calldatas
+        proposer {
+          id
+        }
+      }
+      reason
+      supportDetailed
+    }
+
+    proposals(where: { proposer: $id }) {
+      id
+      description
+      status
+      proposalThreshold
+      quorumVotes
+      forVotes
+      againstVotes
+      abstainVotes
+      createdTransactionHash
+      createdBlock
+      startBlock
+      endBlock
+      executionETA
+      targets
+      values
+      signatures
+      calldatas
+      proposer {
+        id
+      }
+    }
+  }
+`;
+
+export const SNAPSHOT_GOVERNANCE_BY_OWNER_SUB = gql`
+  query governanceProfile($id: String!) {
+    votes(orderBy: "vp", where: { voter: $id, space_in: ["League of Lils", "leagueoflils.eth"] }) {
+      voter
+      vp
+      choice
+      id
+      reason
+      proposal {
+        id
+        title
+        body
+        choices
+        start
+        end
+        snapshot
+        state
+        author
+        scores
+        space {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+export const BIG_NOUNS_PROPOSALS_SUB = gql`
+  query bigNounsProposalData($ids: [String!]!) {
+    proposals(where: { id_in: $ids }) {
+      id
+      description
+      status
+      proposalThreshold
+      quorumVotes
+      forVotes
+      againstVotes
+      abstainVotes
+      createdTransactionHash
+      createdBlock
+      startBlock
+      endBlock
+      executionETA
+      targets
+      values
+      signatures
+      calldatas
+      proposer {
+        id
+      }
+    }
+  }
+`;
+
+export const BIG_NOUNS_GOVERNANCE_BY_OWNER_SUB = gql`
+  query governanceProfile($id: String!) {
+    votes(where: { voter: $id }) {
+      proposal {
+        id
+        description
+        status
+        proposalThreshold
+        quorumVotes
+        forVotes
+        againstVotes
+        abstainVotes
+        createdTransactionHash
+        createdBlock
+        startBlock
+        endBlock
+        executionETA
+        targets
+        values
+        signatures
+        calldatas
+        proposer {
+          id
+        }
+      }
+      supportDetailed
+    }
+
+    proposals(where: { proposer: $id }) {
+      id
+      description
+      status
+      proposalThreshold
+      quorumVotes
+      forVotes
+      againstVotes
+      abstainVotes
+      createdTransactionHash
+      createdBlock
+      startBlock
+      endBlock
+      executionETA
+      targets
+      values
+      signatures
+      calldatas
+      proposer {
+        id
+      }
+    }
+  }
+`;
+
 export const clientFactory = (uri: string) =>
   new ApolloClient({
     uri,


### PR DESCRIPTION
Adding onchain governance activity on proplot profiles.

- I've created a couple of new subgraph queries to fetch proposal voting history, across lil nouns and nouns, based on the profile wallet.
- I refactored some non-proplot code so that I could reuse some utility funtions to format the proposal responses.
- Users can filter their governance lists by nouns or lil nouns voting history
- Added additional profile cards with onchain stats.

Pushed to my own staging env [here](https://eloquent-sunshine-5116fa.netlify.app/proplot/profile/0x8BecD7EbF3F910090f9264DFD0Bb221Ea04af8c3) which seems to be working well.


<img width="973" alt="Screenshot 2022-12-01 at 19 47 01" src="https://user-images.githubusercontent.com/7782211/205145701-e7e70805-18e9-4c13-be25-7f809b4ad86b.png">
