### PR TITLE
fixes styles for close btn

### DIFF
--- a/packages/nouns-webapp/src/components/BidHistoryModal/BidHistoryModal.module.css
+++ b/packages/nouns-webapp/src/components/BidHistoryModal/BidHistoryModal.module.css
@@ -88,6 +88,8 @@
   border-radius: 50%;
   transition: all 0.125s ease-in-out;
   border: 0;
+  padding: 0;
+  color: rgb(0, 0, 0);
 }
 
 .closeBtn:hover {

--- a/packages/nouns-webapp/src/components/InfoModal/InfoModal.module.css
+++ b/packages/nouns-webapp/src/components/InfoModal/InfoModal.module.css
@@ -90,6 +90,8 @@
     border-radius: 50%;
     transition: all 0.125s ease-in-out;
     border: 0;
+    padding: 0;
+    color: rgb(0, 0, 0);
   }
   
   .closeBtn:hover {


### PR DESCRIPTION
This fix mirrors a [PR recently merged](https://github.com/nounsDAO/nouns-monorepo/pull/659) into nounsDAO 

This PR fixes close button styles for iOS 15 where the X is both off-center and blue rather than centered and black as in the desktop version of the site.

This is found in the modals triggered by clicking "Bid history" or "bidding and setting".

<img src="https://user-images.githubusercontent.com/54607186/210442832-b5e798bf-cc3a-4b7e-9592-304a83617711.png" width="300" />

<img src="https://user-images.githubusercontent.com/54607186/210442847-7a5e59d7-867b-4b5e-8c2b-526406961bf9.png" width="300" />

There is an issue with the element getting default user agent stylesheet for iOS and needing the color and padding to be explicitly set. Otherwise it is getting default padding and a [blue color](https://developer.apple.com/forums/thread/690529#:~:text=I%20was%20also%20having%20this%20issue%2C%20and%20tried%20to%20use%20Safari%20developer%20tool%20to%20see%20website%20inspector%20element.%20Found%20%3Cbutton%3E%20color%20style%20use%20%E2%80%9C%2Dapple%2Dsystem%2Dblue%E2%80%9D%2C%20if%20there%20were%20only%20color%20on%20%3Cbody%3E%20or%20not%20set%20anything.).