### PR TITLE
Remove dead links to the PropLot and Discourse

### DIFF
--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -167,13 +167,6 @@ const NavBar = () => {
               </>
             ) : (
               <>
-                <Nav.Link as={Link} to="/proplot" className={classes.nounsNavLink}>
-                  <NavBarButton
-                    buttonText={'Prop Lot'}
-                    buttonIcon={<FontAwesomeIcon icon={faLightbulb} />}
-                    buttonStyle={nonWalletButtonStyle}
-                  />
-                </Nav.Link>
                 <Nav.Link as={Link} to="/vote" className={classes.nounsNavLink}>
                   <NavBarButton
                     buttonText={'DAO'}
@@ -190,18 +183,6 @@ const NavBar = () => {
                   <NavBarButton
                     buttonText={'Docs'}
                     buttonIcon={<FontAwesomeIcon icon={faBookOpen} />}
-                    buttonStyle={nonWalletButtonStyle}
-                  />
-                </Nav.Link>
-                <Nav.Link
-                  href={externalURL(ExternalURL.discourse)}
-                  className={classes.nounsNavLink}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  <NavBarButton
-                    buttonText={'Discourse'}
-                    buttonIcon={<FontAwesomeIcon icon={faComments} />}
                     buttonStyle={nonWalletButtonStyle}
                   />
                 </Nav.Link>


### PR DESCRIPTION
I believe DAO has a valid reason for not choosing Discourse and PropLot. It's highly unlikely they would disregard these options if they found them useful.

https://discord.com/channels/954142017556979752/954146487779078254/1192445142800535623