### PR TITLE
Enhancing Event Context with Timestamps and Delegator Information

### DIFF
--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -5,6 +5,9 @@ type DelegationEvent @entity {
   "The Noun being delegated"
   noun: Noun!
 
+  "Current delegator address"
+  delegator: Account!
+
   "Previous delegate address"
   previousDelegate: Delegate!
 

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -315,6 +315,9 @@ type Vote @entity {
 
   "Block number of vote"
   blockNumber: BigInt!
+
+  "The timestamp of the block the vote is in"
+  blockTimestamp: BigInt!
 }
 
 type Governance @entity {

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -259,6 +259,30 @@ type Proposal @entity {
 
   "Dynamic quorum param snapshot: the dynamic quorum coefficient"
   quorumCoefficient: BigInt!
+
+  "The block number at which this proposal was canceled"
+  canceledBlock: BigInt
+
+  "The timestamp when this proposal was canceled"
+  canceledTimestamp: BigInt
+
+  "The block number at which this proposal was executed"
+  executedBlock: BigInt
+
+  "The timestamp when this proposal was executed"
+  executedTimestamp: BigInt
+
+  "The block number at which this proposal was vetoed"
+  vetoedBlock: BigInt
+
+  "The timestamp when this proposal was vetoed"
+  vetoedTimestamp: BigInt
+
+  "The block number at which this proposal was queued"
+  queuedBlock: BigInt
+
+  "The timestamp when this proposal was queued"
+  queuedTimestamp: BigInt
 }
 
 type Vote @entity {

--- a/packages/nouns-subgraph/src/nouns-dao.ts
+++ b/packages/nouns-subgraph/src/nouns-dao.ts
@@ -104,6 +104,8 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
   let proposal = getOrCreateProposal(event.params.id.toString());
 
   proposal.status = STATUS_CANCELLED;
+  proposal.canceledBlock = event.block.number;
+  proposal.canceledTimestamp = event.block.timestamp;
   proposal.save();
 }
 
@@ -111,6 +113,8 @@ export function handleProposalVetoed(event: ProposalVetoed): void {
   let proposal = getOrCreateProposal(event.params.id.toString());
 
   proposal.status = STATUS_VETOED;
+  proposal.vetoedBlock = event.block.number;
+  proposal.vetoedTimestamp = event.block.timestamp;
   proposal.save();
 }
 
@@ -120,6 +124,8 @@ export function handleProposalQueued(event: ProposalQueued): void {
 
   proposal.status = STATUS_QUEUED;
   proposal.executionETA = event.params.eta;
+  proposal.queuedBlock = event.block.number;
+  proposal.queuedTimestamp = event.block.timestamp;
   proposal.save();
 
   governance.proposalsQueued = governance.proposalsQueued.plus(BIGINT_ONE);
@@ -132,6 +138,8 @@ export function handleProposalExecuted(event: ProposalExecuted): void {
 
   proposal.status = STATUS_EXECUTED;
   proposal.executionETA = null;
+  proposal.executedBlock = event.block.number;
+  proposal.executedTimestamp = event.block.timestamp;
   proposal.save();
 
   governance.proposalsQueued = governance.proposalsQueued.minus(BIGINT_ONE);

--- a/packages/nouns-subgraph/src/nouns-dao.ts
+++ b/packages/nouns-subgraph/src/nouns-dao.ts
@@ -175,6 +175,7 @@ export function handleVoteCast(event: VoteCast): void {
   vote.supportDetailed = event.params.support;
   vote.nouns = voter.nounsRepresented;
   vote.blockNumber = event.block.number;
+  vote.blockTimestamp = event.block.timestamp;
 
   if (event.params.reason != '') {
     vote.reason = event.params.reason;

--- a/packages/nouns-subgraph/src/nouns-erc-721.ts
+++ b/packages/nouns-subgraph/src/nouns-erc-721.ts
@@ -71,6 +71,7 @@ export function handleDelegateChanged(event: DelegateChanged): void {
     delegateChangedEvent.previousDelegate = previousDelegate.id
       ? previousDelegate.id
       : tokenHolder.id;
+    delegateChangedEvent.delegator = tokenHolder.id.toString();
     delegateChangedEvent.newDelegate = newDelegate.id ? newDelegate.id : tokenHolder.id;
     delegateChangedEvent.save();
   }
@@ -174,6 +175,7 @@ export function handleTransfer(event: Transfer): void {
   delegateChangedEvent.newDelegate = toHolder.delegate
     ? toHolder.delegate!.toString()
     : toHolder.id.toString();
+  delegateChangedEvent.delegator = fromHolder.id.toString();
   delegateChangedEvent.save();
 
   let toHolderDelegate = getOrCreateDelegate(toHolder.delegate ? toHolder.delegate! : toHolder.id);


### PR DESCRIPTION
- Introduces a `delegator` field to the `delegateChangedEvent` in the GraphQL schema and Noun's ERC721. This field helps in tracking the current delegator.
- The `blockTimestamp` field is added to the vote entity, allowing the system to keep track of the timestamp for each vote.
- Includes more details about proposal events in the proposal entity, by adding block number and timestamp for each of canceled, vetoed, queued, and executed events.