### PR TITLE
Speed up vrgda auction query

### DIFF
--- a/packages/nouns-webapp/src/index.tsx
+++ b/packages/nouns-webapp/src/index.tsx
@@ -173,14 +173,19 @@ const ChainSubscriber: React.FC = () => {
   // Get the VRGDA auction settings
   useEffect(() => {
     getVrgdaAuctionConfig().then(config => {
-      if (config) dispatch(setConfig(config));
+      if (!config) return;
+      dispatch(setConfig(config));
+      getAndDispatchAuctionsData(config.poolSize);
     });
   }, []);
 
   // Refresh auction data on new blocks
-  useBlockListener(async blockNumber => {
+  useBlockListener(async () => {
     if (typeof poolSize === 'undefined') return;
+    getAndDispatchAuctionsData(poolSize);
+  });
 
+  async function getAndDispatchAuctionsData(poolSize: number) {
     const data = await getVrgdaAuctions(poolSize);
     if (!data) return;
 
@@ -198,7 +203,7 @@ const ChainSubscriber: React.FC = () => {
     );
 
     dispatch(setNouns({ next: data.nextNoun, previous: data.previousNouns }));
-  });
+  }
 
   return <></>;
 };

--- a/packages/nouns-webapp/src/utils/vrgdaAuction.ts
+++ b/packages/nouns-webapp/src/utils/vrgdaAuction.ts
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import { INoun } from '../components/StandaloneNoun';
 import config from '../config';
 
-const FIRST_VRGDA_NOUN_ID = 3;
+const FIRST_VRGDA_NOUN_ID = 7983;
 
 const wsProvider = new ethers.providers.WebSocketProvider(config.app.wsRpcUri);
 


### PR DESCRIPTION
Fix the issue with initial slow query on the homepage.

**Before:**
The first query was executed within new block listener

**After:**
The first query is executed right after we have the vrgda config data


also it adds correct value for the first VRGDA Lil Noun - used by UI to properly display old auctions.