### PR TITLE
Optimize Nouns Subgraph with Timestamp Fixes and Hash Tracking

### DIFF
--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -269,11 +269,17 @@ type Proposal @entity {
   "The timestamp when this proposal was canceled"
   canceledTimestamp: BigInt
 
+  "The transaction hash when the proposal was canceled"
+  canceledTransactionHash: Bytes
+
   "The block number at which this proposal was executed"
   executedBlock: BigInt
 
   "The timestamp when this proposal was executed"
   executedTimestamp: BigInt
+
+  "The transaction hash when the proposal was executed"
+  executedTransactionHash: Bytes
 
   "The block number at which this proposal was vetoed"
   vetoedBlock: BigInt
@@ -281,11 +287,17 @@ type Proposal @entity {
   "The timestamp when this proposal was vetoed"
   vetoedTimestamp: BigInt
 
+  "The transaction hash when the proposal was vetoed"
+  vetoedTransactionHash: Bytes
+
   "The block number at which this proposal was queued"
   queuedBlock: BigInt
 
   "The timestamp when this proposal was queued"
   queuedTimestamp: BigInt
+
+  "The transaction hash when the proposal was queued"
+  queuedTransactionHash: Bytes
 }
 
 type Vote @entity {
@@ -321,6 +333,9 @@ type Vote @entity {
 
   "The timestamp of the block the vote is in"
   blockTimestamp: BigInt!
+
+  "The transaction hash of the vote"
+  transactionHash: Bytes!
 }
 
 type Governance @entity {

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -91,6 +91,9 @@ type Bid @entity {
   "Block number of the bid"
   blockNumber: BigInt!
 
+  "Transaction hash for the bid"
+  txHash: Bytes!
+
   "Index of transaction within block"
   txIndex: BigInt!
 

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -80,7 +80,7 @@ type Bid @entity {
   id: ID!
 
   "The Noun being bid on"
-  noun: Noun!
+  noun: Noun
 
   "Bid amount"
   amount: BigInt!
@@ -112,7 +112,7 @@ type Auction @entity {
   id: ID!
 
   "The Noun"
-  noun: Noun!
+  noun: Noun
 
   "The current highest bid amount"
   amount: BigInt!

--- a/packages/nouns-subgraph/schema.graphql
+++ b/packages/nouns-subgraph/schema.graphql
@@ -131,6 +131,9 @@ type Auction @entity {
 
   "The auction bids"
   bids: [Bid!]! @derivedFrom(field: "auction")
+
+  "Whether the auction uses VRGDA"
+  vrgda: Boolean!
 }
 
 enum ProposalStatus {

--- a/packages/nouns-subgraph/src/lil-vrgda.ts
+++ b/packages/nouns-subgraph/src/lil-vrgda.ts
@@ -39,6 +39,7 @@ export function handleAuctionSettled(event: AuctionSettled): void {
   bid.bidder = bidder.id;
   bid.amount = auction.amount;
   bid.noun = auction.noun;
+  bid.txHash = event.transaction.hash;
   bid.txIndex = event.transaction.index;
   bid.blockNumber = event.block.number;
   bid.blockTimestamp = event.block.timestamp;

--- a/packages/nouns-subgraph/src/lil-vrgda.ts
+++ b/packages/nouns-subgraph/src/lil-vrgda.ts
@@ -29,8 +29,7 @@ export function handleAuctionSettled(event: AuctionSettled): void {
   auction.startTime = BigInt.fromI32(0);
   auction.endTime = BigInt.fromI32(0);
   auction.settled = true;
-
-  // auction.vrgda = true; set to false at nouns-auction-house.ts
+  auction.vrgda = true;
 
   auction.save();
 

--- a/packages/nouns-subgraph/src/lil-vrgda.ts
+++ b/packages/nouns-subgraph/src/lil-vrgda.ts
@@ -18,11 +18,15 @@ export function handleAuctionSettled(event: AuctionSettled): void {
     return;
   }
 
+  const prevNounId = BigInt.fromString(nounId).minus(BigInt.fromI32(1)).toString();
+  const prevAuction = Auction.load(prevNounId);
+  const prevEndTime = prevAuction  ? prevAuction.endTime: event.block.timestamp;
+
   const auction = new Auction(nounId);
   auction.noun = noun.id;
   auction.amount = event.params.amount;
   auction.bidder = bidder.id;
-  auction.startTime = event.block.timestamp;
+  auction.startTime = prevEndTime;
   auction.endTime = event.block.timestamp;
   auction.settled = true;
   auction.vrgda = true;

--- a/packages/nouns-subgraph/src/lil-vrgda.ts
+++ b/packages/nouns-subgraph/src/lil-vrgda.ts
@@ -22,8 +22,8 @@ export function handleAuctionSettled(event: AuctionSettled): void {
   auction.noun = noun.id;
   auction.amount = event.params.amount;
   auction.bidder = bidder.id;
-  auction.startTime = BigInt.fromI32(0);
-  auction.endTime = BigInt.fromI32(0);
+  auction.startTime = event.block.timestamp;
+  auction.endTime = event.block.timestamp;
   auction.settled = true;
   auction.vrgda = true;
   auction.save();

--- a/packages/nouns-subgraph/src/lil-vrgda.ts
+++ b/packages/nouns-subgraph/src/lil-vrgda.ts
@@ -3,17 +3,13 @@ import { Auction, Noun, Bid } from './types/schema';
 import { getOrCreateAccount } from './utils/helpers';
 import { AuctionSettled } from './types/LilVRGDA/LilVRGDA';
 
-// export function handleAuctionReservePriceUpdated(event: AuctionReservePriceUpdated): void {
-// event.params.reservePrice
-// }
-
 export function handleAuctionSettled(event: AuctionSettled): void {
-  let nounId = event.params.nounId.toString();
-  let bidderAddress = event.params.winner.toHex();
+  const nounId = event.params.nounId.toString();
+  const bidderAddress = event.params.winner.toHex();
 
-  let bidder = getOrCreateAccount(bidderAddress);
+  const bidder = getOrCreateAccount(bidderAddress);
 
-  let noun = Noun.load(nounId);
+  const noun = Noun.load(nounId);
   if (noun == null) {
     log.error('[handleAuctionCreated] Noun #{} not found. Hash: {}', [
       nounId,
@@ -22,7 +18,7 @@ export function handleAuctionSettled(event: AuctionSettled): void {
     return;
   }
 
-  let auction = new Auction(nounId); //VRGDA(nounId);
+  const auction = new Auction(nounId);
   auction.noun = noun.id;
   auction.amount = event.params.amount;
   auction.bidder = bidder.id;
@@ -30,11 +26,10 @@ export function handleAuctionSettled(event: AuctionSettled): void {
   auction.endTime = BigInt.fromI32(0);
   auction.settled = true;
   auction.vrgda = true;
-
   auction.save();
 
   // Save Bid (Buy)
-  let bid = new Bid(event.transaction.hash.toHex());
+  const bid = new Bid(event.transaction.hash.toHex());
   bid.bidder = bidder.id;
   bid.amount = auction.amount;
   bid.noun = auction.noun;
@@ -43,13 +38,7 @@ export function handleAuctionSettled(event: AuctionSettled): void {
   bid.blockNumber = event.block.number;
   bid.blockTimestamp = event.block.timestamp;
   bid.auction = auction.id;
-
-  // if (event.params.comment != '') {
-  //   bid.comment = event.params.comment;
-  // } else {
-    bid.comment = '';
-  // }
-
+  bid.comment = '';
   bid.save();
 }
 

--- a/packages/nouns-subgraph/src/lil-vrgda.ts
+++ b/packages/nouns-subgraph/src/lil-vrgda.ts
@@ -1,4 +1,4 @@
-import { BigInt, log } from '@graphprotocol/graph-ts'
+import { BigInt, log } from '@graphprotocol/graph-ts';
 import { Auction, Noun, Bid } from './types/schema';
 import { getOrCreateAccount } from './utils/helpers';
 import { AuctionSettled } from './types/LilVRGDA/LilVRGDA';
@@ -7,42 +7,54 @@ export function handleAuctionSettled(event: AuctionSettled): void {
   const nounId = event.params.nounId.toString();
   const bidderAddress = event.params.winner.toHex();
 
-  const bidder = getOrCreateAccount(bidderAddress);
-
+  // Fetch the noun information
   const noun = Noun.load(nounId);
-  if (noun == null) {
-    log.error('[handleAuctionCreated] Noun #{} not found. Hash: {}', [
-      nounId,
-      event.transaction.hash.toHex(),
-    ]);
+  if (!noun) {
+    log.error('[handleAuctionSettled] Noun #{} not found. Hash: {}', [nounId, event.transaction.hash.toHex()]);
     return;
   }
 
-  const prevNounId = BigInt.fromString(nounId).minus(BigInt.fromI32(1)).toString();
-  const prevAuction = Auction.load(prevNounId);
-  const prevEndTime = prevAuction  ? prevAuction.endTime: event.block.timestamp;
+  const bidder = getOrCreateAccount(bidderAddress);
 
-  const auction = new Auction(nounId);
-  auction.noun = noun.id;
-  auction.amount = event.params.amount;
-  auction.bidder = bidder.id;
-  auction.startTime = prevEndTime;
-  auction.endTime = event.block.timestamp;
-  auction.settled = true;
-  auction.vrgda = true;
-  auction.save();
+  // Load the settled auction
+  let settledAuction = Auction.load(nounId);
+  if (!settledAuction) {
+    settledAuction = new Auction(nounId);
+    settledAuction.noun = noun.id;
+    settledAuction.startTime = event.block.timestamp;
+    settledAuction.amount = BigInt.zero();
+    settledAuction.settled = true;
+    settledAuction.vrgda = true;
+  }
+  settledAuction.amount = event.params.amount;
+  settledAuction.bidder = bidder.id;
+  settledAuction.endTime = event.block.timestamp;
+  settledAuction.save();
 
-  // Save Bid (Buy)
+  // Create and save the bid
   const bid = new Bid(event.transaction.hash.toHex());
   bid.bidder = bidder.id;
-  bid.amount = auction.amount;
-  bid.noun = auction.noun;
+  bid.amount = event.params.amount;
+  bid.noun = noun.id;
   bid.txHash = event.transaction.hash;
   bid.txIndex = event.transaction.index;
   bid.blockNumber = event.block.number;
   bid.blockTimestamp = event.block.timestamp;
-  bid.auction = auction.id;
+  bid.auction = settledAuction.id;
   bid.comment = '';
   bid.save();
-}
 
+  // Determine the next auction ID, ensuring after x9 is x2
+  const increment = nounId.endsWith('9') ? BigInt.fromI32(3) : BigInt.fromI32(1);
+  const newAuctionId = BigInt.fromString(nounId).plus(increment).toString();
+
+  // Create and save the new auction
+  const newAuction = new Auction(newAuctionId);
+  newAuction.noun = noun.id;
+  newAuction.startTime = event.block.timestamp.plus(BigInt.fromI32(1));
+  newAuction.endTime = BigInt.zero()
+  newAuction.amount = BigInt.zero()
+  newAuction.settled = false;
+  newAuction.vrgda = true;
+  newAuction.save();
+}

--- a/packages/nouns-subgraph/src/lil-vrgda.ts
+++ b/packages/nouns-subgraph/src/lil-vrgda.ts
@@ -20,12 +20,12 @@ export function handleAuctionSettled(event: AuctionSettled): void {
   let settledAuction = Auction.load(nounId);
   if (!settledAuction) {
     settledAuction = new Auction(nounId);
-    settledAuction.noun = noun.id;
     settledAuction.startTime = event.block.timestamp;
     settledAuction.amount = BigInt.zero();
     settledAuction.settled = true;
     settledAuction.vrgda = true;
   }
+  settledAuction.noun = noun.id;
   settledAuction.amount = event.params.amount;
   settledAuction.bidder = bidder.id;
   settledAuction.endTime = event.block.timestamp;
@@ -50,7 +50,7 @@ export function handleAuctionSettled(event: AuctionSettled): void {
 
   // Create and save the new auction
   const newAuction = new Auction(newAuctionId);
-  newAuction.noun = noun.id;
+  newAuction.noun = null;
   newAuction.startTime = event.block.timestamp.plus(BigInt.fromI32(1));
   newAuction.endTime = BigInt.zero()
   newAuction.amount = BigInt.zero()

--- a/packages/nouns-subgraph/src/lil-vrgda.ts
+++ b/packages/nouns-subgraph/src/lil-vrgda.ts
@@ -22,9 +22,9 @@ export function handleAuctionSettled(event: AuctionSettled): void {
     settledAuction = new Auction(nounId);
     settledAuction.startTime = event.block.timestamp;
     settledAuction.amount = BigInt.zero();
-    settledAuction.settled = true;
     settledAuction.vrgda = true;
   }
+  settledAuction.settled = true;
   settledAuction.noun = noun.id;
   settledAuction.amount = event.params.amount;
   settledAuction.bidder = bidder.id;

--- a/packages/nouns-subgraph/src/nouns-auction-house.ts
+++ b/packages/nouns-subgraph/src/nouns-auction-house.ts
@@ -53,6 +53,7 @@ export function handleAuctionBid(event: AuctionBid): void {
   bid.bidder = bidder.id;
   bid.amount = auction.amount;
   bid.noun = auction.noun;
+  bid.txHash = event.transaction.hash;
   bid.txIndex = event.transaction.index;
   bid.blockNumber = event.block.number;
   bid.blockTimestamp = event.block.timestamp;
@@ -144,6 +145,7 @@ export function handleAuctionBidV1(event: AuctionBid): void {
   bid.bidder = bidder.id;
   bid.amount = auction.amount;
   bid.noun = auction.noun;
+  bid.txHash = event.transaction.hash;
   bid.txIndex = event.transaction.index;
   bid.blockNumber = event.block.number;
   bid.blockTimestamp = event.block.timestamp;

--- a/packages/nouns-subgraph/src/nouns-auction-house.ts
+++ b/packages/nouns-subgraph/src/nouns-auction-house.ts
@@ -26,6 +26,7 @@ export function handleAuctionCreated(event: AuctionCreated): void {
   auction.startTime = event.params.startTime;
   auction.endTime = event.params.endTime;
   auction.settled = false;
+  auction.vrgda = false;
   auction.save();
 }
 

--- a/packages/nouns-subgraph/src/nouns-auction-house.ts
+++ b/packages/nouns-subgraph/src/nouns-auction-house.ts
@@ -9,9 +9,9 @@ import { Auction, Noun, Bid } from './types/schema';
 import { getOrCreateAccount } from './utils/helpers';
 
 export function handleAuctionCreated(event: AuctionCreated): void {
-  let nounId = event.params.nounId.toString();
+  const nounId = event.params.nounId.toString();
 
-  let noun = Noun.load(nounId);
+  const noun = Noun.load(nounId);
   if (noun == null) {
     log.error('[handleAuctionCreated] Noun #{} not found. Hash: {}', [
       nounId,
@@ -20,7 +20,7 @@ export function handleAuctionCreated(event: AuctionCreated): void {
     return;
   }
 
-  let auction = new Auction(nounId);
+  const auction = new Auction(nounId);
   auction.noun = noun.id;
   auction.amount = BigInt.fromI32(0);
   auction.startTime = event.params.startTime;
@@ -31,12 +31,12 @@ export function handleAuctionCreated(event: AuctionCreated): void {
 }
 
 export function handleAuctionBid(event: AuctionBid): void {
-  let nounId = event.params.nounId.toString();
-  let bidderAddress = event.params.sender.toHex();
+  const nounId = event.params.nounId.toString();
+  const bidderAddress = event.params.sender.toHex();
 
-  let bidder = getOrCreateAccount(bidderAddress);
+  const bidder = getOrCreateAccount(bidderAddress);
 
-  let auction = Auction.load(nounId);
+  const auction = Auction.load(nounId);
   if (auction == null) {
     log.error('[handleAuctionBid] Auction not found for Noun #{}. Hash: {}', [
       nounId,
@@ -50,7 +50,7 @@ export function handleAuctionBid(event: AuctionBid): void {
   auction.save();
 
   // Save Bid
-  let bid = new Bid(event.transaction.hash.toHex());
+  const bid = new Bid(event.transaction.hash.toHex());
   bid.bidder = bidder.id;
   bid.amount = auction.amount;
   bid.noun = auction.noun;
@@ -70,9 +70,9 @@ export function handleAuctionBid(event: AuctionBid): void {
 }
 
 export function handleAuctionExtended(event: AuctionExtended): void {
-  let nounId = event.params.nounId.toString();
+  const nounId = event.params.nounId.toString();
 
-  let auction = Auction.load(nounId);
+  const auction = Auction.load(nounId);
   if (auction == null) {
     log.error('[handleAuctionExtended] Auction not found for Noun #{}. Hash: {}', [
       nounId,
@@ -86,9 +86,9 @@ export function handleAuctionExtended(event: AuctionExtended): void {
 }
 
 export function handleAuctionSettled(event: AuctionSettled): void {
-  let nounId = event.params.nounId.toString();
+  const nounId = event.params.nounId.toString();
 
-  let auction = Auction.load(nounId);
+  const auction = Auction.load(nounId);
   if (auction == null) {
     log.error('[handleAuctionSettled] Auction not found for Noun #{}. Hash: {}', [
       nounId,
@@ -102,9 +102,9 @@ export function handleAuctionSettled(event: AuctionSettled): void {
 }
 
 export function handleAuctionCreatedV1(event: AuctionCreated): void {
-  let nounId = event.params.nounId.toString();
+  const nounId = event.params.nounId.toString();
 
-  let noun = Noun.load(nounId);
+  const noun = Noun.load(nounId);
   if (noun == null) {
     log.error('[handleAuctionCreated] Noun #{} not found. Hash: {}', [
       nounId,
@@ -113,7 +113,7 @@ export function handleAuctionCreatedV1(event: AuctionCreated): void {
     return;
   }
 
-  let auction = new Auction(nounId);
+  const auction = new Auction(nounId);
   auction.noun = noun.id;
   auction.amount = BigInt.fromI32(0);
   auction.startTime = event.params.startTime;
@@ -123,12 +123,12 @@ export function handleAuctionCreatedV1(event: AuctionCreated): void {
 }
 
 export function handleAuctionBidV1(event: AuctionBid): void {
-  let nounId = event.params.nounId.toString();
-  let bidderAddress = event.params.sender.toHex();
+  const nounId = event.params.nounId.toString();
+  const bidderAddress = event.params.sender.toHex();
 
-  let bidder = getOrCreateAccount(bidderAddress);
+  const bidder = getOrCreateAccount(bidderAddress);
 
-  let auction = Auction.load(nounId);
+  const auction = Auction.load(nounId);
   if (auction == null) {
     log.error('[handleAuctionBid] Auction not found for Noun #{}. Hash: {}', [
       nounId,
@@ -142,7 +142,7 @@ export function handleAuctionBidV1(event: AuctionBid): void {
   auction.save();
 
   // Save Bid
-  let bid = new Bid(event.transaction.hash.toHex());
+  const bid = new Bid(event.transaction.hash.toHex());
   bid.bidder = bidder.id;
   bid.amount = auction.amount;
   bid.noun = auction.noun;
@@ -157,9 +157,9 @@ export function handleAuctionBidV1(event: AuctionBid): void {
 }
 
 export function handleAuctionExtendedV1(event: AuctionExtended): void {
-  let nounId = event.params.nounId.toString();
+  const nounId = event.params.nounId.toString();
 
-  let auction = Auction.load(nounId);
+  const auction = Auction.load(nounId);
   if (auction == null) {
     log.error('[handleAuctionExtended] Auction not found for Noun #{}. Hash: {}', [
       nounId,
@@ -173,9 +173,9 @@ export function handleAuctionExtendedV1(event: AuctionExtended): void {
 }
 
 export function handleAuctionSettledV1(event: AuctionSettled): void {
-  let nounId = event.params.nounId.toString();
+  const nounId = event.params.nounId.toString();
 
-  let auction = Auction.load(nounId);
+  const auction = Auction.load(nounId);
   if (auction == null) {
     log.error('[handleAuctionSettled] Auction not found for Noun #{}. Hash: {}', [
       nounId,

--- a/packages/nouns-subgraph/src/nouns-dao.ts
+++ b/packages/nouns-subgraph/src/nouns-dao.ts
@@ -106,6 +106,7 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
   proposal.status = STATUS_CANCELLED;
   proposal.canceledBlock = event.block.number;
   proposal.canceledTimestamp = event.block.timestamp;
+  proposal.canceledTransactionHash = event.transaction.hash;
   proposal.save();
 }
 
@@ -115,6 +116,7 @@ export function handleProposalVetoed(event: ProposalVetoed): void {
   proposal.status = STATUS_VETOED;
   proposal.vetoedBlock = event.block.number;
   proposal.vetoedTimestamp = event.block.timestamp;
+  proposal.vetoedTransactionHash = event.transaction.hash;
   proposal.save();
 }
 
@@ -126,6 +128,7 @@ export function handleProposalQueued(event: ProposalQueued): void {
   proposal.executionETA = event.params.eta;
   proposal.queuedBlock = event.block.number;
   proposal.queuedTimestamp = event.block.timestamp;
+  proposal.queuedTransactionHash = event.transaction.hash;
   proposal.save();
 
   governance.proposalsQueued = governance.proposalsQueued.plus(BIGINT_ONE);
@@ -140,6 +143,7 @@ export function handleProposalExecuted(event: ProposalExecuted): void {
   proposal.executionETA = null;
   proposal.executedBlock = event.block.number;
   proposal.executedTimestamp = event.block.timestamp;
+  proposal.executedTransactionHash = event.transaction.hash;
   proposal.save();
 
   governance.proposalsQueued = governance.proposalsQueued.minus(BIGINT_ONE);
@@ -176,6 +180,7 @@ export function handleVoteCast(event: VoteCast): void {
   vote.nouns = voter.nounsRepresented;
   vote.blockNumber = event.block.number;
   vote.blockTimestamp = event.block.timestamp;
+  vote.transactionHash = event.transaction.hash;
 
   if (event.params.reason != '') {
     vote.reason = event.params.reason;

--- a/packages/nouns-subgraph/src/nouns-dao.ts
+++ b/packages/nouns-subgraph/src/nouns-dao.ts
@@ -37,7 +37,7 @@ import { dynamicQuorumVotes } from './utils/dynamicQuorum';
  */
 function extractTitle(description: string): string {
   // Extract a markdown title from a proposal body that uses the `# Title` or `Title\n===` formats
-  let splitDescription = description.split('#', 3);
+  const splitDescription = description.split('#', 3);
   if (splitDescription.length > 1) {
     splitDescription.shift(); // Remove any characters before `#`
   }
@@ -55,7 +55,7 @@ function extractTitle(description: string): string {
 export function handleProposalCreatedWithRequirements(
   event: ProposalCreatedWithRequirements,
 ): void {
-  let proposal = getOrCreateProposal(event.params.id.toString());
+  const proposal = getOrCreateProposal(event.params.id.toString());
   let proposer = getOrCreateDelegateWithNullOption(event.params.proposer.toHexString(), false);
 
   // Check if the proposer was a delegate already accounted for, if not we should log an error
@@ -101,7 +101,7 @@ export function handleProposalCreatedWithRequirements(
 }
 
 export function handleProposalCanceled(event: ProposalCanceled): void {
-  let proposal = getOrCreateProposal(event.params.id.toString());
+  const proposal = getOrCreateProposal(event.params.id.toString());
 
   proposal.status = STATUS_CANCELLED;
   proposal.canceledBlock = event.block.number;
@@ -111,7 +111,7 @@ export function handleProposalCanceled(event: ProposalCanceled): void {
 }
 
 export function handleProposalVetoed(event: ProposalVetoed): void {
-  let proposal = getOrCreateProposal(event.params.id.toString());
+  const proposal = getOrCreateProposal(event.params.id.toString());
 
   proposal.status = STATUS_VETOED;
   proposal.vetoedBlock = event.block.number;
@@ -121,8 +121,8 @@ export function handleProposalVetoed(event: ProposalVetoed): void {
 }
 
 export function handleProposalQueued(event: ProposalQueued): void {
-  let governance = getGovernanceEntity();
-  let proposal = getOrCreateProposal(event.params.id.toString());
+  const governance = getGovernanceEntity();
+  const proposal = getOrCreateProposal(event.params.id.toString());
 
   proposal.status = STATUS_QUEUED;
   proposal.executionETA = event.params.eta;
@@ -136,8 +136,8 @@ export function handleProposalQueued(event: ProposalQueued): void {
 }
 
 export function handleProposalExecuted(event: ProposalExecuted): void {
-  let governance = getGovernanceEntity();
-  let proposal = getOrCreateProposal(event.params.id.toString());
+  const governance = getGovernanceEntity();
+  const proposal = getOrCreateProposal(event.params.id.toString());
 
   proposal.status = STATUS_EXECUTED;
   proposal.executionETA = null;
@@ -151,12 +151,12 @@ export function handleProposalExecuted(event: ProposalExecuted): void {
 }
 
 export function handleVoteCast(event: VoteCast): void {
-  let proposal = getOrCreateProposal(event.params.proposalId.toString());
-  let voteId = event.params.voter
+  const proposal = getOrCreateProposal(event.params.proposalId.toString());
+  const voteId = event.params.voter
     .toHexString()
     .concat('-')
     .concat(event.params.proposalId.toString());
-  let vote = getOrCreateVote(voteId);
+  const vote = getOrCreateVote(voteId);
   let voter = getOrCreateDelegateWithNullOption(event.params.voter.toHexString(), false);
 
   // Check if the voter was a delegate already accounted for, if not we should log an error

--- a/packages/nouns-subgraph/src/nouns-erc-721.ts
+++ b/packages/nouns-subgraph/src/nouns-erc-721.ts
@@ -10,9 +10,9 @@ import { BIGINT_ONE, BIGINT_ZERO, ZERO_ADDRESS } from './utils/constants';
 import { getGovernanceEntity, getOrCreateDelegate, getOrCreateAccount } from './utils/helpers';
 
 export function handleNounCreated(event: NounCreated): void {
-  let nounId = event.params.tokenId.toString();
+  const nounId = event.params.tokenId.toString();
 
-  let seed = new Seed(nounId);
+  const seed = new Seed(nounId);
   seed.background = event.params.seed.background;
   seed.body = event.params.seed.body;
   seed.accessory = event.params.seed.accessory;
@@ -20,7 +20,7 @@ export function handleNounCreated(event: NounCreated): void {
   seed.glasses = event.params.seed.glasses;
   seed.save();
 
-  let noun = Noun.load(nounId);
+  const noun = Noun.load(nounId);
   if (noun == null) {
     log.error('[handleNounCreated] Noun #{} not found. Hash: {}', [
       nounId,
@@ -37,9 +37,9 @@ export function handleNounCreated(event: NounCreated): void {
 let accountNouns: string[] = [];
 
 export function handleDelegateChanged(event: DelegateChanged): void {
-  let tokenHolder = getOrCreateAccount(event.params.delegator.toHexString());
-  let previousDelegate = getOrCreateDelegate(event.params.fromDelegate.toHexString());
-  let newDelegate = getOrCreateDelegate(event.params.toDelegate.toHexString());
+  const tokenHolder = getOrCreateAccount(event.params.delegator.toHexString());
+  const previousDelegate = getOrCreateDelegate(event.params.fromDelegate.toHexString());
+  const newDelegate = getOrCreateDelegate(event.params.toDelegate.toHexString());
   accountNouns = tokenHolder.nouns;
 
   tokenHolder.delegate = newDelegate.id;
@@ -47,12 +47,12 @@ export function handleDelegateChanged(event: DelegateChanged): void {
 
   previousDelegate.tokenHoldersRepresentedAmount =
     previousDelegate.tokenHoldersRepresentedAmount - 1;
-  let previousNounsRepresented = previousDelegate.nounsRepresented; // Re-assignment required to update array
+  const previousNounsRepresented = previousDelegate.nounsRepresented; // Re-assignment required to update array
   previousDelegate.nounsRepresented = previousNounsRepresented.filter(
     n => !accountNouns.includes(n),
   );
   newDelegate.tokenHoldersRepresentedAmount = newDelegate.tokenHoldersRepresentedAmount + 1;
-  let newNounsRepresented = newDelegate.nounsRepresented; // Re-assignment required to update array
+  const newNounsRepresented = newDelegate.nounsRepresented; // Re-assignment required to update array
   for (let i = 0; i < accountNouns.length; i++) {
     newNounsRepresented.push(accountNouns[i]);
   }
@@ -62,7 +62,7 @@ export function handleDelegateChanged(event: DelegateChanged): void {
 
   // Log a transfer event for each Noun
   for (let i = 0; i < accountNouns.length; i++) {
-    let delegateChangedEvent = new DelegationEvent(
+    const delegateChangedEvent = new DelegationEvent(
       event.transaction.hash.toHexString() + '_' + accountNouns[i],
     );
     delegateChangedEvent.blockNumber = event.block.number;
@@ -78,9 +78,9 @@ export function handleDelegateChanged(event: DelegateChanged): void {
 }
 
 export function handleDelegateVotesChanged(event: DelegateVotesChanged): void {
-  let governance = getGovernanceEntity();
-  let delegate = getOrCreateDelegate(event.params.delegate.toHexString());
-  let votesDifference = event.params.newBalance.minus(event.params.previousBalance);
+  const governance = getGovernanceEntity();
+  const delegate = getOrCreateDelegate(event.params.delegate.toHexString());
+  const votesDifference = event.params.newBalance.minus(event.params.previousBalance);
 
   delegate.delegatedVotesRaw = event.params.newBalance;
   delegate.delegatedVotes = event.params.newBalance;
@@ -99,12 +99,12 @@ export function handleDelegateVotesChanged(event: DelegateVotesChanged): void {
 
 let transferredNounId: string; // Use WebAssembly global due to lack of closure support
 export function handleTransfer(event: Transfer): void {
-  let fromHolder = getOrCreateAccount(event.params.from.toHexString());
-  let toHolder = getOrCreateAccount(event.params.to.toHexString());
-  let governance = getGovernanceEntity();
+  const fromHolder = getOrCreateAccount(event.params.from.toHexString());
+  const toHolder = getOrCreateAccount(event.params.to.toHexString());
+  const governance = getGovernanceEntity();
   transferredNounId = event.params.tokenId.toString();
 
-  let transferEvent = new TransferEvent(
+  const transferEvent = new TransferEvent(
     event.transaction.hash.toHexString() + '_' + transferredNounId,
   );
   transferEvent.blockNumber = event.block.number;
@@ -119,15 +119,15 @@ export function handleTransfer(event: Transfer): void {
     governance.totalTokenHolders = governance.totalTokenHolders.plus(BIGINT_ONE);
     governance.save();
   } else {
-    let fromHolderPreviousBalance = fromHolder.tokenBalanceRaw;
+    const fromHolderPreviousBalance = fromHolder.tokenBalanceRaw;
     fromHolder.tokenBalanceRaw = fromHolder.tokenBalanceRaw.minus(BIGINT_ONE);
     fromHolder.tokenBalance = fromHolder.tokenBalanceRaw;
-    let fromHolderNouns = fromHolder.nouns; // Re-assignment required to update array
+    const fromHolderNouns = fromHolder.nouns; // Re-assignment required to update array
     fromHolder.nouns = fromHolderNouns.filter(n => n != transferredNounId);
 
     if (fromHolder.delegate != null) {
-      let fromHolderDelegate = getOrCreateDelegate(fromHolder.delegate as string);
-      let fromHolderNounsRepresented = fromHolderDelegate.nounsRepresented; // Re-assignment required to update array
+      const fromHolderDelegate = getOrCreateDelegate(fromHolder.delegate as string);
+      const fromHolderNounsRepresented = fromHolderDelegate.nounsRepresented; // Re-assignment required to update array
       fromHolderDelegate.nounsRepresented = fromHolderNounsRepresented.filter(
         n => n != transferredNounId,
       );
@@ -163,7 +163,7 @@ export function handleTransfer(event: Transfer): void {
     governance.save();
   }
 
-  let delegateChangedEvent = new DelegationEvent(
+  const delegateChangedEvent = new DelegationEvent(
     event.transaction.hash.toHexString() + '_' + event.params.tokenId.toString(),
   );
   delegateChangedEvent.blockNumber = event.block.number;
@@ -178,18 +178,18 @@ export function handleTransfer(event: Transfer): void {
   delegateChangedEvent.delegator = fromHolder.id.toString();
   delegateChangedEvent.save();
 
-  let toHolderDelegate = getOrCreateDelegate(toHolder.delegate ? toHolder.delegate! : toHolder.id);
-  let toHolderNounsRepresented = toHolderDelegate.nounsRepresented; // Re-assignment required to update array
+  const toHolderDelegate = getOrCreateDelegate(toHolder.delegate ? toHolder.delegate! : toHolder.id);
+  const toHolderNounsRepresented = toHolderDelegate.nounsRepresented; // Re-assignment required to update array
   toHolderNounsRepresented.push(transferredNounId);
   toHolderDelegate.nounsRepresented = toHolderNounsRepresented;
   toHolderDelegate.save();
 
-  let toHolderPreviousBalance = toHolder.tokenBalanceRaw;
+  const toHolderPreviousBalance = toHolder.tokenBalanceRaw;
   toHolder.tokenBalanceRaw = toHolder.tokenBalanceRaw.plus(BIGINT_ONE);
   toHolder.tokenBalance = toHolder.tokenBalanceRaw;
   toHolder.totalTokensHeldRaw = toHolder.totalTokensHeldRaw.plus(BIGINT_ONE);
   toHolder.totalTokensHeld = toHolder.totalTokensHeldRaw;
-  let toHolderNouns = toHolder.nouns; // Re-assignment required to update array
+  const toHolderNouns = toHolder.nouns; // Re-assignment required to update array
   toHolderNouns.push(event.params.tokenId.toString());
   toHolder.nouns = toHolderNouns;
 


### PR DESCRIPTION
- Set auction start time to previous auction's end time to fix incorrect auction timestamps.
- Replaced `let` with `const` for variables that do not require reassignment.
- Added `vrgda` field to the `auction` entity.
- Added transaction hash field to `bid` entity.
- Added transaction hash fields for proposals and votes to improve traceability.